### PR TITLE
Boosting VaaS in Vagrant user experience

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "vaas", primary: true do |vaas|
 
-    vaas.vm.box_url = "http://box.allegro.tech/vaas_dev_v0.04.box"
-    vaas.vm.box = "vaas_dev_v0.04.box"
+    vaas.vm.box_url = "http://box.allegro.tech/vaas_dev_v0.05.box"
+    vaas.vm.box = "vaas_dev_v0.05.box"
 
     vaas.vm.synced_folder ".", "/home/vagrant/vaas"
 

--- a/docs/quick-start/vagrant.md
+++ b/docs/quick-start/vagrant.md
@@ -26,6 +26,8 @@ Point your browser to <http://192.168.200.11:3030/> and log in using the followi
 
 You will see a django admin GUI with two apps: Cluster and Manager. Configure your sample Varnish servers and VCL templates in Cluster app. Configure your backends, directors and probes in the Manager app. Reffer to [GUI](../documentation/gui.md) or [API](../documentation/api.md) documentation to see how to do this.
 
+Current VCL for the test Varnish instances can be previewed by clicking on Cluster -> Varnish servers -> Show vcl. HINT: Freshly after booting up VaaS in Vagrant, the configuration of the Varnish servers will not be loaded. Make some changes to the test backends or re-enable the test Varnish instances to trigger loading of the configuration.
+
 Entering the VaaS box
 ---------------------
 You can access the Vagrant box and make modifications as you require (eg. to run more Varnish or backend instances):

--- a/vagrant/puppet/manifests/default.pp
+++ b/vagrant/puppet/manifests/default.pp
@@ -1,6 +1,6 @@
 node default {
 
-  class { 'grub2': cmdline_linux => 'cgroup_enable=memory swapaccount=1'; } ->
+  class { 'grub2': cmdline_linux => 'apparmor=0 cgroup_enable=memory swapaccount=1'; } ->
   class { 'containers': } ->
   class { 'vaas_service': }
 


### PR DESCRIPTION
 - fixing problems with containers randomly not starting up
 - adding a note in documentation about triggering loading of configuration to Varnish instances after boot up