### PR TITLE
Bump django-ace to 1.2.4

### DIFF
--- a/vaas-app/requirements/base.txt
+++ b/vaas-app/requirements/base.txt
@@ -16,4 +16,4 @@ django-taggit==0.22.1
 celery==4.0.2
 redis==2.10.5
 -e git+https://github.com/TheMickeyMike/django-admin-bootstrapped@master#egg=django_admin_bootstrapped-2.5.8
--e git+https://github.com/marcinzaremba/django-ace.git@v1.2.3#egg=django_ace-1.2.3
+-e git+https://github.com/TheMickeyMike/django-ace.git@v1.2.4#egg=django_ace-1.2.4


### PR DESCRIPTION
This version of django-ace fixing overlapping max-min button during editing VCL