### PR TITLE
Bump to Django 1.11.2 | Removing Gdal libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:14.04
 RUN apt-get update &&\
-    apt-get install -y python python-virtualenv git python-dev python-pip python-setupdocs sqlite3 nginx libsasl2-dev libldap2-dev libssl-dev redis-server \
-    binutils libproj-dev gdal-bin &&\
+    apt-get install -y python python-virtualenv git python-dev python-pip python-setupdocs sqlite3 nginx libsasl2-dev libldap2-dev libssl-dev redis-server &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* &&\
     rm /etc/nginx/sites-enabled/default

--- a/vaas-app/requirements/base.txt
+++ b/vaas-app/requirements/base.txt
@@ -1,4 +1,4 @@
-django==1.11.1
+django==1.11.2
 python-varnish==0.2.1
 django_nose==1.4.4
 enum34==1.1.6

--- a/vagrant/shell/vaas.sh
+++ b/vagrant/shell/vaas.sh
@@ -4,7 +4,7 @@ VAAS_SRC_HOME='/home/vagrant/vaas/vaas-app/src'
 
 # prepare repositories
 sudo apt-get update -y
-sudo apt-get install -y redis-server python-dev binutils libproj-dev gdal-bin
+sudo apt-get install -y redis-server python-dev
 
 sudo ~/venv/bin/docker-compose -f ~/vaas/docker-compose.yml up -d --force-recreate
 


### PR DESCRIPTION
Now Django raises ImproperlyConfigured instead unsupported by Tastypie GDALException. More in PR [#148](https://github.com/allegro/vaas/pull/148)