### PR TITLE
Cluster refresh optimalization - don't refresh unnecessary clusters, …

### DIFF
--- a/vaas-app/src/vaas/manager/api.py
+++ b/vaas-app/src/vaas/manager/api.py
@@ -75,7 +75,7 @@ class DirectorResource(ModelResource):
         try:
             new_uris = bundle.obj.new_clusters_uris
             bundle.obj.new_clusters = [cluster.obj for cluster in bundle.data['cluster']
-                            if cluster.data['resource_uri'] in new_uris]
+                                       if cluster.data['resource_uri'] in new_uris]
             logger.info("[DirectorResource.save_m2m()] new_clusters = {}".format(bundle.obj.new_clusters))
         except (AttributeError, KeyError):
             pass

--- a/vaas-app/src/vaas/manager/api.py
+++ b/vaas-app/src/vaas/manager/api.py
@@ -14,6 +14,8 @@ from vaas.manager.forms import ProbeModelForm, DirectorModelForm, BackendModelFo
 from vaas.manager.models import Backend, Probe, Director, TimeProfile
 from vaas.monitor.models import BackendStatus
 
+logger = logging.getLogger('vaas')
+
 
 class TimeProfileResource(ModelResource):
     class Meta:
@@ -71,24 +73,22 @@ class DirectorResource(ModelResource):
         }
 
     def save_m2m(self, bundle):
-        logger = logging.getLogger('vaas')
         try:
             new_uris = bundle.obj.new_clusters_uris
             bundle.obj.new_clusters = [cluster.obj for cluster in bundle.data['cluster']
                                        if cluster.data['resource_uri'] in new_uris]
-            logger.info("[DirectorResource.save_m2m()] new_clusters = {}".format(bundle.obj.new_clusters))
+            logger.info("[DirectorResource.save_m2m()] new_clusters = %s", bundle.obj.new_clusters)
         except (AttributeError, KeyError):
             pass
 
         return super(DirectorResource, self).save_m2m(bundle)
 
     def update_in_place(self, request, original_bundle, new_data):
-        logger = logging.getLogger('vaas')
         try:
             original_bundle.obj.old_clusters = list(original_bundle.obj.cluster.all())
         except AttributeError:
             original_bundle.obj.old_clusters = []
-        logger.info("[DirectorResource.update_in_place()] old_clusters = {}".format(original_bundle.obj.old_clusters))
+        logger.info("[DirectorResource.update_in_place()] old_clusters = %s", original_bundle.obj.old_clusters)
         try:
             original_bundle.obj.new_clusters_uris = new_data['cluster']
         except KeyError:

--- a/vaas-app/src/vaas/manager/signals.py
+++ b/vaas-app/src/vaas/manager/signals.py
@@ -121,7 +121,7 @@ def vcl_update(sender, **kwargs):
     elif sender is Director:
         if not is_only_cluster_update(instance):
             for cluster in instance.cluster.all():
-                logger.debug("vcl_update(): %s" % str(cluster))
+                logger.debug("vcl_update(): %s", str(cluster))
                 if cluster not in clusters_to_refresh:
                     clusters_to_refresh.append(cluster)
     # VarnishServer
@@ -171,8 +171,8 @@ def director_update(**kwargs):
         return
 
     clusters_to_refresh = get_clusters_to_refresh(instance)
-    logger.info("[director_update(instance={}, action={})] Clusters to refresh: {}"
-                .format(instance, action, clusters_to_refresh))
+    logger.info("[director_update(instance=%s, action=%s)] Clusters to refresh: %s",
+                instance, action, clusters_to_refresh)
     regenerate_and_reload_vcl(clusters_to_refresh)
     mark_cluster_as_refreshed(instance, clusters_to_refresh)
 

--- a/vaas-app/src/vaas/manager/signals.py
+++ b/vaas-app/src/vaas/manager/signals.py
@@ -119,10 +119,11 @@ def vcl_update(sender, **kwargs):
                 clusters_to_refresh.append(cluster)
     # Director
     elif sender is Director:
-        for cluster in instance.cluster.all():
-            logger.debug("vcl_update(): %s" % str(cluster))
-            if cluster not in clusters_to_refresh:
-                clusters_to_refresh.append(cluster)
+        if not is_only_cluster_update(instance):
+            for cluster in instance.cluster.all():
+                logger.debug("vcl_update(): %s" % str(cluster))
+                if cluster not in clusters_to_refresh:
+                    clusters_to_refresh.append(cluster)
     # VarnishServer
     elif sender is VarnishServer:
         cluster = instance.cluster
@@ -150,6 +151,8 @@ def vcl_update(sender, **kwargs):
                         clusters_to_refresh.append(cluster)
 
     regenerate_and_reload_vcl(clusters_to_refresh)
+    if sender is Director:
+        reset_refreshed_clusters(instance)
 
 
 @receiver(pre_delete)
@@ -162,11 +165,49 @@ def clean_up_tags(sender, **kwargs):
 def director_update(**kwargs):
     logger = logging.getLogger('vaas')
     instance = kwargs['instance']
-    clusters_to_refresh = []
-    for cluster in instance.cluster.all():
-        logger.debug("director_update(): %s" % str(cluster))
-        if cluster not in clusters_to_refresh:
-            clusters_to_refresh.append(cluster)
+    action = kwargs['action']
+
+    if action not in ['post_add', 'pre_remove', 'pre_clear']:
+        return
+
+    clusters_to_refresh = get_clusters_to_refresh(instance)
+    logger.info("[director_update(instance={}, action={})] Clusters to refresh: {}"
+                .format(instance, action, clusters_to_refresh))
     regenerate_and_reload_vcl(clusters_to_refresh)
+    mark_cluster_as_refreshed(instance, clusters_to_refresh)
+
+
+def get_clusters_to_refresh(instance):
+    all_clusters = list(instance.cluster.all())
+    try:
+        new_clusters_set = set(instance.new_clusters)
+        old_clusters_set = set(instance.old_clusters)
+        diff_clusters_set = old_clusters_set.symmetric_difference(new_clusters_set)
+        try:
+            clusters_to_refresh_set = diff_clusters_set.difference(instance.refreshed_clusters)
+        except AttributeError:
+            clusters_to_refresh_set = diff_clusters_set
+        return list(clusters_to_refresh_set.intersection(set(all_clusters)))
+    except (AttributeError, TypeError):
+        return all_clusters
+
+
+def mark_cluster_as_refreshed(director, clusters):
+    try:
+        director.refreshed_clusters |= set(clusters)
+    except AttributeError:
+        director.refreshed_clusters = set(clusters)
+
+
+def reset_refreshed_clusters(director):
+    director.refreshed_clusters = set()
+
+
+def is_only_cluster_update(instance):
+    try:
+        return set(instance.new_data.keys()) == {'cluster'}
+    except AttributeError:
+        return False
+
 
 m2m_changed.connect(director_update, sender=Director.cluster.through)

--- a/vaas-app/src/vaas/manager/tests/test_signals.py
+++ b/vaas-app/src/vaas/manager/tests/test_signals.py
@@ -307,7 +307,7 @@ def test_vcl_update_only_changed_clusters_for_director():
         director2.cluster.remove(cluster3)
         assert_equals([call([cluster3])], regenerate_and_reload_vcl_mock.call_args_list)
 
-    with patch('vaas.manager.signals.regenerate_and_reload_vcl',return_value=None) as regenerate_and_reload_vcl_mock:
+    with patch('vaas.manager.signals.regenerate_and_reload_vcl', return_value=None) as regenerate_and_reload_vcl_mock:
         kwargs = {'instance': director2, 'action': 'post_add'}
         director2.cluster.add(cluster5)
         assert_equals([call([cluster5])], regenerate_and_reload_vcl_mock.call_args_list)
@@ -325,10 +325,9 @@ def test_vcl_update_only_changed_clusters_for_director():
         director2.cluster.remove(cluster3)
         assert_equals([call([cluster3, cluster4])], regenerate_and_reload_vcl_mock.call_args_list)
 
-    with patch('vaas.manager.signals.regenerate_and_reload_vcl',return_value=None) as regenerate_and_reload_vcl_mock:
+    with patch('vaas.manager.signals.regenerate_and_reload_vcl', return_value=None) as regenerate_and_reload_vcl_mock:
         kwargs = {'instance': director2, 'action': 'post_add'}
         director2.cluster.add(cluster5)
         assert_equals([call([cluster4, cluster5])], regenerate_and_reload_vcl_mock.call_args_list)
 
     settings.SIGNALS = 'off'
-

--- a/vaas-app/src/vaas/manager/tests/test_signals.py
+++ b/vaas-app/src/vaas/manager/tests/test_signals.py
@@ -270,8 +270,65 @@ def test_vcl_update_cluster_filter_for_director_via_related_manager():
     director1.cluster.add(cluster1)
 
     with patch('vaas.manager.signals.regenerate_and_reload_vcl', return_value=None) as regenerate_and_reload_vcl_mock:
-        kwargs = {'instance': director1}
+        kwargs = {'instance': director1, 'action': 'post_add'}
         director_update(**kwargs)
         assert_equals([call([cluster1])], regenerate_and_reload_vcl_mock.call_args_list)
 
     settings.SIGNALS = 'off'
+
+
+def test_vcl_update_only_changed_clusters_for_director():
+    settings.SIGNALS = 'on'
+
+    cluster3 = LogicalCluster.objects.create(name="cluster3")
+    cluster4 = LogicalCluster.objects.create(name="cluster4")
+    cluster5 = LogicalCluster.objects.create(name="cluster5")
+
+    probe1 = Probe.objects.create(name='test_director2_probe', url='/status')
+    director2 = Director.objects.create(
+        name='director2',
+        router='req.url',
+        route_expression='/first',
+        probe=probe1,
+        active_active=False,
+        mode='round-robin',
+        remove_path=False,
+        time_profile=TimeProfile.objects.create(name='timeprofile2')
+    )
+    director2.cluster.add(cluster3, cluster4)
+    director2.save()
+
+    director2.old_clusters = [cluster3, cluster4]
+    director2.new_clusters = [cluster4, cluster5]
+    director2.new_data = {'cluster': object()}
+
+    with patch('vaas.manager.signals.regenerate_and_reload_vcl', return_value=None) as regenerate_and_reload_vcl_mock:
+        kwargs = {'instance': director2, 'action': 'pre_clear'}
+        director2.cluster.remove(cluster3)
+        assert_equals([call([cluster3])], regenerate_and_reload_vcl_mock.call_args_list)
+
+    with patch('vaas.manager.signals.regenerate_and_reload_vcl',return_value=None) as regenerate_and_reload_vcl_mock:
+        kwargs = {'instance': director2, 'action': 'post_add'}
+        director2.cluster.add(cluster5)
+        assert_equals([call([cluster5])], regenerate_and_reload_vcl_mock.call_args_list)
+
+    # should update all clusters when change metadata is not set
+
+    director2.cluster.clear()
+    director2.cluster.add(cluster3, cluster4)
+    director2.save()
+    del director2.new_clusters
+    del director2.old_clusters
+
+    with patch('vaas.manager.signals.regenerate_and_reload_vcl', return_value=None) as regenerate_and_reload_vcl_mock:
+        kwargs = {'instance': director2, 'action': 'pre_clear'}
+        director2.cluster.remove(cluster3)
+        assert_equals([call([cluster3, cluster4])], regenerate_and_reload_vcl_mock.call_args_list)
+
+    with patch('vaas.manager.signals.regenerate_and_reload_vcl',return_value=None) as regenerate_and_reload_vcl_mock:
+        kwargs = {'instance': director2, 'action': 'post_add'}
+        director2.cluster.add(cluster5)
+        assert_equals([call([cluster4, cluster5])], regenerate_and_reload_vcl_mock.call_args_list)
+
+    settings.SIGNALS = 'off'
+


### PR DESCRIPTION
Currently, when director is updated, always all its clusters are refreshed (even multiple times).

This change is very basic optimalization - if only "cluster" field on director is updated, refresh only changed clusters.

Optimalization is aplied only to API PUT and PATCH requests