### PR TITLE
Tear down length restriction on URL to purge

### DIFF
--- a/vaas-app/src/vaas/purger/forms.py
+++ b/vaas-app/src/vaas/purger/forms.py
@@ -4,7 +4,7 @@ from vaas.cluster.models import LogicalCluster
 
 
 class PurgeForm(forms.Form):
-    url = forms.CharField(label='Url to purge', max_length=100, validators=[URLValidator()])
+    url = forms.CharField(label='Url to purge', validators=[URLValidator()])
     cluster = forms.ModelChoiceField(
         label='Varnish cluster', queryset=LogicalCluster.objects.all()
     )


### PR DESCRIPTION
As rfc states: there should not be any request line length restriction https://tools.ietf.org/html/rfc7230#section-3.1.1