### PR TITLE
Proper backend health checks handling with Varnish v6.0 LTS

### DIFF
--- a/vaas-app/src/vaas/monitor/health.py
+++ b/vaas-app/src/vaas/monitor/health.py
@@ -44,8 +44,12 @@ class BackendStatusManager(object):
                             else:
                                 self.logger.error('Regex patterns matches for possible backend id: {} '
                                                   .format(regex_result))
-
-                            status = backend_status[-2]
+                            # for varnish v6.0 LTS
+                            if len(backend_status) == 10:
+                                status = backend_status[-8]
+                            else:
+                                # for varnish v4
+                                status = backend_status[-2]
                             if backend_id and backend_id not in backend_to_status_map or status == 'Sick':
                                 backend_address = backends.get(backend_id)
                                 if backend_address is not None:


### PR DESCRIPTION
Splitted output line from varnishadm backend.list looks as follows:
Varnish 4.1:
> ['second_service_4_dc1_199_13_80(192.168.199.13,,80)', '1', 'probe', 'Healthy', '5/5']

Varnish 6.0 LTS:
> ['vagrant_template_4-20190220_15_03_56-vol_2f530.second_service_4_dc1_199_13_80', 'probe', 'Healthy', '5/5', 'Wed,', '20', 'Feb', '2019', '15:03:56', 'GMT']

There is need to handle it in vaas-app/src/vaas/monitor/health.py