### PR TITLE
Add filtering for routes

### DIFF
--- a/vaas-app/requirements/base.txt
+++ b/vaas-app/requirements/base.txt
@@ -3,10 +3,10 @@ django_nose==1.4.4
 enum34==1.1.6
 wheel==0.29.0
 PyYAML==3.12
-jinja2>=2.10.1
+jinja2==2.10.1
 django-tastypie==0.13.3
 django-log-request-id==1.3.2
-MarkupSafe==1.0
+MarkupSafe==1.1
 nose>=1.3.4
 django-simple-history==1.8.2
 django-secure==1.0.1

--- a/vaas-app/src/vaas/router/api.py
+++ b/vaas-app/src/vaas/router/api.py
@@ -26,7 +26,8 @@ class RouteResource(ModelResource):
         always_return_data = True
         filtering = {
             'director': ALL_WITH_RELATIONS,
-            'clusters': ALL_WITH_RELATIONS
+            'clusters': ALL_WITH_RELATIONS,
+            'condition': ['icontains']
         }
 
     def hydrate_condition(self, bundle):


### PR DESCRIPTION
Example usage:

```
curl -i "http://localhost:3030/api/v0.1/route/?condition__icontains=flex&username=admin&api_key=api_key&format=json"
HTTP/1.0 200 OK
Date: Wed, 19 Feb 2020 11:16:51 GMT
Server: WSGIServer/0.2 CPython/3.5.2
Content-Length: 396
Vary: Accept, Cookie
X-Frame-Options: SAMEORIGIN
Content-Type: application/json
Cache-Control: no-cache
x-content-type-options: nosniff

{
  "meta": {
    "limit": 20,
    "next": null,
    "offset": 0,
    "previous": null,
    "total_count": 1
  },
  "objects": [
    {
      "action": "pass",
      "clusters": [
        "cluster4_siteC_prod"
      ],
      "condition": "req.url ~ \"^\\/flexibleee\"",
      "director": "second_service",
      "id": 1,
      "priority": 51,
      "resource_uri": "/api/v0.1/route/1/"
    }
  ]
}
```