### PR TITLE
Fix installation on production #297 + remove cache keys for ldap using lck.django

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "pluton", autostart: false do |pluton|
 
-    pluton.vm.box = "ubuntu/xenial64"
+    pluton.vm.box = "ubuntu/focal64"
     pluton.vm.synced_folder ".", "/home/vagrant/vaas"
     pluton.vm.provision :shell, :privileged => false, :path => "vagrant/shell/pluton.sh"
     pluton.vm.provision :shell, :privileged => false, :path => "vagrant/shell/prepare_git_repo.sh"

--- a/docs/quick-start/production.md
+++ b/docs/quick-start/production.md
@@ -16,6 +16,7 @@ Build VaaS package
 ------------------
 Use the commands below to build VaaS from source:
 
+    cd ~/
     git clone https://github.com/allegro/vaas.git
     python3.9 -m venv dist-env
     . dist-env/bin/activate
@@ -31,13 +32,13 @@ Install VaaS package
 --------------------
 Use the commands below to install VaaS package built in the previous step on a web server:
 
+    cd ~/
     python3.9 -m venv prod-env
     . prod-env/bin/activate
     pip install --upgrade pip
     pip install python-ldap==3.3.1
     pip install django-auth-ldap==2.2.0
     pip install mysqlclient==2.0.3
-    pip install lck.django
     pip install uwsgi
     pip install vaas-{version-number}.zip
 

--- a/vaas-app/src/vaas/external/ldap_config.py
+++ b/vaas-app/src/vaas/external/ldap_config.py
@@ -8,7 +8,6 @@ from __future__ import unicode_literals
 
 from django_auth_ldap.config import ActiveDirectoryGroupType
 from django.utils.encoding import force_unicode
-from lck.django import cache
 
 # Add default value to LDAPSetting dict. It will be replaced by
 # django_auth_ldap with value in settings.py and visible for each
@@ -20,18 +19,11 @@ class MappedGroupOfNamesType(ActiveDirectoryGroupType):
 
     """Provide group mappings described in project settings."""
 
-    def _group_cache_key(self, group_dn):
-        return force_unicode(group_dn).replace(' ', '_').replace('\n', '')
-
     def _get_group(self, group_dn, ldap_user, group_search):
-        key = self._group_cache_key(group_dn)
-        group = cache.get(key)
-        if not group:
-            base_dn = group_search.base_dn
-            group_search.base_dn = force_unicode(group_dn)
-            group = group_search.execute(ldap_user.connection)[0]
-            group_search.base_dn = base_dn
-            cache.set(key, group, timeout=GROUP_CACHE_TIMEOUT)
+        base_dn = group_search.base_dn
+        group_search.base_dn = force_unicode(group_dn)
+        group = group_search.execute(ldap_user.connection)[0]
+        group_search.base_dn = base_dn
         return group
 
     def user_groups(self, ldap_user, group_search):


### PR DESCRIPTION
Now we don't support cached keys for ldap groups.
Also fix installation process in documentation.