### PR TITLE
Default vcl variables

### DIFF
--- a/vaas-app/src/vaas/manager/models.py
+++ b/vaas-app/src/vaas/manager/models.py
@@ -118,7 +118,7 @@ class Director(models.Model):
         help_text='<i>Virtual director will not be available in routes</i>',
     )
     reachable_via_service_mesh = models.BooleanField(
-        default=True,
+        default=False,
         help_text='<i>Pass traffic to backends via service mesh if varnish cluster supports it</i>',
     )
 

--- a/vaas-app/src/vaas/settings/base.py
+++ b/vaas-app/src/vaas/settings/base.py
@@ -194,6 +194,11 @@ ROUTES_LEFT_CONDITIONS = env.dict('ROUTES_LEFT_CONDITIONS', default={
     'req.http.X-Example': 'X-Example',
 })
 
+DEFAULT_VCL_VARIABLES = env.dict('DEFAULT_VCL_VARIABLES', default={
+    'MESH_IP': '127.0.0.1',
+    'MESH_PORT': '31001',
+})
+
 PURGER_HTTP_CLIENT_TIMEOUT = env.int('PURGER_HTTP_CLIENT_TIMEOUT', default=10)
 PURGER_MAX_HTTP_WORKERS = env.int('PURGER_MAX_HTTP_WORKERS', default=100)
 

--- a/vaas-app/src/vaas/vcl/tests/test_renderer.py
+++ b/vaas-app/src/vaas/vcl/tests/test_renderer.py
@@ -554,7 +554,7 @@ class VclVariableExpanderTest(TestCase):
         self.variables = [self.variable, self.variable_2]
 
     def test_should_expand_variable_in_appropriate_cluster(self):
-        content = VclVariableExpander(self.cluster.id, self.variables).expand_variables(
+        content = VclVariableExpander(self.cluster.id, self.variables, {}).expand_variables(
             '''\
 <VCL/>
 ## #{vcl_variable} ##
@@ -563,6 +563,27 @@ class VclVariableExpanderTest(TestCase):
         )
         expected_content = '''\
 <VCL/>
+## vcl_variable_value ##
+## #{vcl_variable_2} ##
+'''
+
+        assert_equals(content, expected_content)
+
+    def test_should_expand_variable_with_default_value_only_as_fallback(self):
+        default_values = {'vcl_not_defined_variable': 'vcl_fallback_value'}
+        content = VclVariableExpander(
+            self.cluster.id, self.variables, default_values
+        ).expand_variables(
+            '''\
+<VCL/>
+## #{vcl_not_defined_variable} ##
+## #{vcl_variable} ##
+## #{vcl_variable_2} ##
+'''
+        )
+        expected_content = '''\
+<VCL/>
+## vcl_fallback_value ##
 ## vcl_variable_value ##
 ## #{vcl_variable_2} ##
 '''


### PR DESCRIPTION
- Define default vcl variables as fallback for missing cluster vcl variables
- Temporary switch reachable_via_service_mesh to false by default