### PR TITLE
migrate time.time to time.perf_counter for more precisely counter

### DIFF
--- a/vaas-app/src/vaas/cluster/cluster.py
+++ b/vaas-app/src/vaas/cluster/cluster.py
@@ -169,10 +169,10 @@ class ParallelRenderer(ParallelExecutor):
     def render_vcl_for_servers(self, vcl_name, servers):
         vcl_list = []
 
-        start = time.time()
+        start = time.perf_counter()
         render_input = VclRendererInput()
-        self.logger.debug("vcl's prepare input data: %f" % (time.time() - start))
-        start = time.time()
+        self.logger.debug("vcl's prepare input data: %f" % (time.perf_counter() - start))
+        start = time.perf_counter()
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             future_results = []
             for server in servers:
@@ -182,7 +182,7 @@ class ParallelRenderer(ParallelExecutor):
             for server, future_result in future_results:
                 vcl_list.append(tuple([server, future_result.result()]))
 
-        self.logger.debug("vcl's render time: %f" % (time.time() - start))
+        self.logger.debug("vcl's render time: %f" % (time.perf_counter() - start))
         return vcl_list
 
 
@@ -218,7 +218,7 @@ class ParallelLoader(ParallelExecutor):
     @collect_processing
     def load_vcl_list(self, vcl_list):
         to_use = []
-        start = time.time()
+        start = time.perf_counter()
         aggregated_result = True
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             future_results = []
@@ -242,7 +242,7 @@ class ParallelLoader(ParallelExecutor):
 
                 raise e
 
-        self.logger.debug("vcl's loaded: %f" % (time.time() - start))
+        self.logger.debug("vcl's loaded: %f" % (time.perf_counter() - start))
 
         return self._format_vcl_list(to_use, aggregated_result)
 
@@ -250,7 +250,7 @@ class ParallelLoader(ParallelExecutor):
     def use_vcl_list(self, vcl_name, vcl_loaded_list):
         self.logger.info("Call use vcl for %d servers" % len(vcl_loaded_list))
         result = True
-        start = time.time()
+        start = time.perf_counter()
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             future_results = []
@@ -269,6 +269,6 @@ class ParallelLoader(ParallelExecutor):
                 if status.result() is VclStatus.ERROR:
                     self.logger.debug("ERROR while discard vcl's on %s" % (server))
 
-        self.logger.debug("vcl's used: %f" % (time.time() - start))
+        self.logger.debug("vcl's used: %f" % (time.perf_counter() - start))
 
         return result

--- a/vaas-app/src/vaas/manager/middleware.py
+++ b/vaas-app/src/vaas/manager/middleware.py
@@ -77,7 +77,7 @@ class VclRefreshMiddleware:
             del request.session['error_message']
 
         if len(clusters) > 0:
-            start = time.time()
+            start = time.perf_counter()
             try:
                 result = load_vcl_task.delay(
                     timezone.now(),
@@ -110,7 +110,7 @@ class VclRefreshMiddleware:
                     return HttpApplicationError("%s: %s" % (e.__class__.__name__, str(e)[:400]))
                 request.session['error_message'] = "%s: %s" % (e.__class__.__name__, unescape_exception(e))
 
-            logging.info("cluster reload time: %f" % (time.time() - start))
+            logging.info("cluster reload time: %f" % (time.perf_counter() - start))
         return response
 
 

--- a/vaas-app/src/vaas/vcl/loader.py
+++ b/vaas-app/src/vaas/vcl/loader.py
@@ -27,22 +27,22 @@ class VclLoader(object):
 
     def load_new_vcl(self, vcl):
         try:
-            start = time.time()
+            start = time.perf_counter()
             """Load and use newest vcl"""
             if self.vcl_has_changed(vcl) is True:
                 self.logger.debug(
-                    "[%s] vcl '%s' has changed: %f" % (self.varnish_api.id, vcl.name, time.time() - start)
+                    "[%s] vcl '%s' has changed: %f" % (self.varnish_api.id, vcl.name, time.perf_counter() - start)
                 )
-                start = time.time()
+                start = time.perf_counter()
                 if self.varnish_api.vcl_inline(vcl.name, '<< EOF\n' + str(vcl) + 'EOF')[0][0] == 200:
                     self.logger.debug(
-                        "[%s] vcl '%s' has loaded: %f" % (self.varnish_api.id, vcl.name, time.time() - start)
+                        "[%s] vcl '%s' has loaded: %f" % (self.varnish_api.id, vcl.name, time.perf_counter() - start)
                     )
                     return VclStatus.OK
                 return VclStatus.ERROR
             else:
                 self.logger.debug(
-                    "[%s] vcl '%s' has no changes: %f" % (self.varnish_api.id, vcl.name, time.time() - start)
+                    "[%s] vcl '%s' has no changes: %f" % (self.varnish_api.id, vcl.name, time.perf_counter() - start)
                 )
                 return VclStatus.NO_CHANGES
         except Exception as e:
@@ -51,17 +51,17 @@ class VclLoader(object):
             raise VclLoadException(e)
 
     def use_vcl(self, vcl):
-        start = time.time()
+        start = time.perf_counter()
         if self.varnish_api.vcl_use(vcl.name)[0][0] == 200:
             self.logger.debug(
-                "[%s] vcl '%s' used: %f" % (self.varnish_api.id, vcl.name, time.time() - start)
+                "[%s] vcl '%s' used: %f" % (self.varnish_api.id, vcl.name, time.perf_counter() - start)
             )
             return VclStatus.OK
         return VclStatus.ERROR
 
     def discard_unused_vcls(self):
         """Discard unused vcls"""
-        start = time.time()
+        start = time.perf_counter()
         vcls = self.varnish_api.vcls()['available']
         return_value = VclStatus.NO_CHANGES.value
         for vcl in vcls:
@@ -77,6 +77,6 @@ class VclLoader(object):
                 return_value = max(return_value, VclStatus.ERROR.value)
 
         self.logger.debug(
-            "[%s] old vcl discarded: %f" % (self.varnish_api.id, time.time() - start)
+            "[%s] old vcl discarded: %f" % (self.varnish_api.id, time.perf_counter() - start)
         )
         return VclStatus(return_value)

--- a/vaas-app/src/vaas/vcl/renderer.py
+++ b/vaas-app/src/vaas/vcl/renderer.py
@@ -52,13 +52,13 @@ def collect_processing(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         global processing_stats
-        start = time.time()
+        start = time.perf_counter()
         r = func(*args, **kwargs)
         name = func.__name__
         if name not in processing_stats:
             processing_stats[name] = {'time': 0, 'calls': 0}
         processing_stats[name]['calls'] += 1
-        processing_stats[name]['time'] += time.time() - start
+        processing_stats[name]['time'] += time.perf_counter() - start
         return r
     return wrapper
 
@@ -389,10 +389,10 @@ class VclRendererInput(object):
 class VclRenderer(object):
     def render(self, varnish, version, input):
         try:
-            start = time.time()
+            start = time.perf_counter()
             vcl_tag_builder = VclTagBuilder(varnish, input)
             logging.getLogger('vaas').debug(
-                "[%s] vcl tag builder prepare time: %f" % (varnish.ip, time.time() - start)
+                "[%s] vcl tag builder prepare time: %f" % (varnish.ip, time.perf_counter() - start)
             )
 
             content = varnish.template.content
@@ -417,7 +417,7 @@ class VclRenderer(object):
             content = content.replace("\r", '')
             vcl = Vcl(content, name=str(varnish.template.name + '-' + version))
             logging.getLogger('vaas').debug(
-                "[%s] vcl '%s' rendering time: %f" % (varnish.ip, vcl.name, time.time() - start)
+                "[%s] vcl '%s' rendering time: %f" % (varnish.ip, vcl.name, time.perf_counter() - start)
             )
             return vcl
         except:


### PR DESCRIPTION
In python 3.3 was added more precisely time counter. It's called ```time.perf_counter()```
And after that is a good practice to stop uses ```time.time()``` method.
More is about [here](https://www.webucator.com/article/python-clocks-explained/).