### PR TITLE
Add new option for API authentication

### DIFF
--- a/vaas-app/src/vaas/external/oauth.py
+++ b/vaas-app/src/vaas/external/oauth.py
@@ -1,10 +1,11 @@
 import importlib
 from django.conf import settings
-from tastypie.authentication import MultiAuthentication
+from tastypie.authentication import Authentication, MultiAuthentication
 
 # If Oauth for API is enabled & custom module (OAUTH_AUTH_MODULE) is not present,
 # default TastyPie OAuthAuthentication backend will be used
 
+API_ALLOW_ALL = getattr(settings, 'API_ALLOW_ALL', False)
 API_OAUTH_ENABLED = getattr(settings, 'API_OAUTH_ENABLED', False)
 OAUTH_AUTH_MODULE = getattr(settings, 'OAUTH_AUTH_MODULE', 'tastypie.authentication')
 
@@ -18,4 +19,8 @@ class VaasMultiAuthentication(MultiAuthentication):
         super(MultiAuthentication, self).__init__(**kwargs)
         if API_OAUTH_ENABLED:
             backends = backends + (OAuthAuthentication(),)
+        # AllowAll is added last to the list, as it is possible
+        # that the user may have been authenticated by previous backends
+        if API_ALLOW_ALL:
+            backends = backends + (Authentication(),)
         self.backends = backends


### PR DESCRIPTION
If you want no-op authentication in API resources using `VaasMultiAuthentication`, set variable `API_ALLOW_ALL=True` in your app settings.py.
