### PR TITLE
Parallel gathering backend statuses

### DIFF
--- a/vaas/vaas/adminext/templates/admin/error_dialog.html
+++ b/vaas/vaas/adminext/templates/admin/error_dialog.html
@@ -1,5 +1,5 @@
 <!-- Modal -->
-{% if request.session.error_message %}
+{% if 'error_message' in request.session %}
 <script>
     $(document).ready(function(){
         $('#errModal').modal('show');

--- a/vaas/vaas/cluster/cluster.py
+++ b/vaas/vaas/cluster/cluster.py
@@ -127,14 +127,6 @@ class VarnishApiProvider(object):
         for server in ServerExtractor().servers:
             yield self.get_api(server, timeout)
 
-    def get_connected_varnish_api(self, timeout=1):
-        for server in ServerExtractor().servers:
-            try:
-                varnish_api = self.get_api(server, timeout)
-                yield varnish_api
-            except VclLoadException:
-                continue
-
 
 class ServerExtractor(object):
 

--- a/vaas/vaas/cluster/helpers.py
+++ b/vaas/vaas/cluster/helpers.py
@@ -9,7 +9,7 @@ class BaseHelpers:
         dcs = Dc.objects.all()
         dcs_regex_pattern = ''
         for idx, dc in enumerate(dcs):
-            dcs_regex_pattern += '{}'.format(dc.symbol)
+            dcs_regex_pattern += '{}'.format(dc.normalized_symbol)
             if not idx == len(dcs) - 1:
                 dcs_regex_pattern += '|'
         return re.compile("(\d+)_({})".format(dcs_regex_pattern))

--- a/vaas/vaas/cluster/tests/test_cluster.py
+++ b/vaas/vaas/cluster/tests/test_cluster.py
@@ -70,39 +70,6 @@ class VarnishApiProviderTest(TestCase):
                 assert_equals(3, len(api_objects))
                 assert_list_equal(expected_construct_args, construct_mock.call_args_list)
 
-    def test_should_create_varnish_api_for_connected_servers(self):
-        expected_construct_args = [
-            call(['127.0.0.1', '6082', 1.0], 'secret-1'),
-            call(['127.0.0.2', '6083', 1.0], 'secret-2'),
-            call(['127.0.0.3', '6084', 1.0], 'secret-3')]
-        sample_extractor = Mock(servers=servers)
-
-        api_init_side_effect = {
-            'secret-1': Exception(),
-            'secret-2': None,
-            'secret-3': None
-        }
-
-        with patch('vaas.cluster.cluster.ServerExtractor', Mock(return_value=sample_extractor)):
-            with patch.object(
-                    VarnishApi, '__init__', side_effect=lambda host_port_timeout, secret: api_init_side_effect[secret]
-            ) as construct_mock:
-                with patch('telnetlib.Telnet.close', Mock()):
-                    varnish_cluster = VarnishApiProvider()
-                    api_objects = []
-                    for api in varnish_cluster.get_connected_varnish_api():
-                        """
-                        Workaround - we cannot mock __del__ method:
-                        https://docs.python.org/3/library/unittest.mock.html
-
-                        We inject sock field to eliminate warning raised by cleaning actions in __del__ method
-                        """
-                        api.sock = None
-                        api_objects.append(api)
-
-                    assert_equals(2, len(api_objects))
-                    assert_list_equal(expected_construct_args, construct_mock.call_args_list)
-
     def test_should_throw_vcl_load_exception_on_any_error_while_connecting_to_varnish_api(self):
         with patch.object(VarnishApi, '__init__', side_effect=Exception):
             with patch.object(VarnishApi, '__del__'):

--- a/vaas/vaas/manager/templates/cluster/admin_app_varnishserver_description.html
+++ b/vaas/vaas/manager/templates/cluster/admin_app_varnishserver_description.html
@@ -9,6 +9,7 @@
         vcl_modal.on('hidden.bs.modal', function (e) {
             $(this).find('.modal-body').empty();
         });
+
     })
 </script>
 <div class="modal fade" id="vclModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/vaas/vaas/monitor/health.py
+++ b/vaas/vaas/monitor/health.py
@@ -4,6 +4,8 @@ import re
 import datetime
 import logging
 
+from concurrent.futures import ThreadPoolExecutor
+from django.conf import settings
 from django.utils.timezone import utc
 
 from vaas.monitor.models import BackendStatus
@@ -12,65 +14,97 @@ from vaas.cluster.cluster import VarnishApiProvider, VclLoadException, ServerExt
 from vaas.cluster.helpers import BaseHelpers
 
 
+def provide_backend_status_manager():
+    return BackendStatusManager(
+        VarnishApiProvider(),
+        ServerExtractor().servers,
+        settings.VAAS_GATHER_STATUSES_CONNECT_TIMEOUT,
+        settings.VAAS_GATHER_STATUSES_MAX_WORKERS
+    )
+
+
 class BackendStatusManager(object):
-    def __init__(self):
-        self.varnish_api_provider = VarnishApiProvider()
+
+    def __init__(self, varnish_api_provider, servers, connect_timeout=0.1, workers=30):
         self.logger = logging.getLogger(__name__)
+        self.varnish_api_provider = varnish_api_provider
+        self.servers = servers
+        self.backends = {x.pk: f"{x.address}:{x.port}" for x in Backend.objects.all()}
         self.timestamp = datetime.datetime.utcnow().replace(tzinfo=utc, microsecond=0)
+        self.CONNECT_TIMEOUT = connect_timeout
+        self.WORKERS = workers
 
     def load_from_varnish(self):
-        pattern = re.compile("^((?:.*_){5}[^(\s]*)")
+        backend_pattern = re.compile("^((?:.*_){5}[^(\s]*)")
+        dc_pattern = BaseHelpers.dynamic_regex_with_datacenters()
         backend_to_status_map = {}
-        backends = {x.pk: "{}:{}".format(x.address, x.port) for x in Backend.objects.all()}
-
-        try:
-            for varnish_api in self.varnish_api_provider.get_connected_varnish_api():
-                backend_statuses = map(lambda x: x.split(), varnish_api.fetch('backend.list')[1][0:].split('\n'))
-
-                for backend_status in backend_statuses:
-                    if len(backend_status):
-                        backend = re.search(pattern, backend_status[0])
-                        if backend is not None:
-                            backend_id = None
-                            regex_result = re.findall(BaseHelpers.dynamic_regex_with_datacenters(), backend.group(1))
-
-                            if len(regex_result) == 1:
-                                try:
-                                    backend_id = int(regex_result[0][0])
-                                except ValueError:
-                                    self.logger.error(
-                                        'Mapping backend id failed. Expected parsable string to int, got {}'.format(
-                                            regex_result[0][0]))
-
-                            # for varnish v6.0 LTS
-                            if len(backend_status) == 10:
-                                status = backend_status[-8]
-                            else:
-                                # for varnish v4
-                                status = backend_status[-2]
-                            if backend_id and backend_id not in backend_to_status_map or status == 'Sick':
-                                backend_address = backends.get(backend_id)
-                                if backend_address is not None:
-                                    backend_to_status_map[backend_address] = status
-
-        except VclLoadException as e:
-            self.logger.warning("Some backends' status could not be refreshed: %s" % e)
-
+        with ThreadPoolExecutor(max_workers=self.WORKERS) as executor:
+            future_results = []
+            for server in self.servers:
+                future_results.append(
+                    executor.submit(self._load_from_single_varnish, backend_pattern, dc_pattern, server)
+                )
+            for future_result in future_results:
+                for address, status in future_result.result().items():
+                    if backend_to_status_map.get(address) != 'Sick':
+                        backend_to_status_map[address] = status
         return backend_to_status_map
 
+    def _load_from_single_varnish(self, pattern, dc_pattern, server):
+        backend_to_status_map = {}
+        try:
+            varnish_api = self.varnish_api_provider.get_api(server, self.CONNECT_TIMEOUT)
+            backend_statuses = map(lambda x: x.split(), varnish_api.fetch('backend.list')[1][0:].split('\n'))
+            for backend_status in backend_statuses:
+                if len(backend_status):
+                    backend = re.search(pattern, backend_status[0])
+                    if backend is not None:
+                        backend_id = None
+                        regex_result = re.findall(dc_pattern, backend.group(1))
+                        if len(regex_result) == 1:
+                            try:
+                                backend_id = int(regex_result[0][0])
+                            except ValueError:
+                                self.logger.error(
+                                    'Mapping backend id failed. Expected parsable string to int, got {}'.format(
+                                        regex_result[0][0]))
+                        # for varnish v6.0 LTS
+                        if len(backend_status) == 10:
+                            status = backend_status[-8]
+                        else:
+                            # for varnish v4
+                            status = backend_status[-2]
+
+                        if backend_id and backend_id not in backend_to_status_map or status == 'Sick':
+                            backend_address = self.backends.get(backend_id)
+                            if backend_address is not None:
+                                backend_to_status_map[backend_address] = status
+        finally:
+            return backend_to_status_map
+
     def store_backend_statuses(self, backend_to_status_map):
+        existing_statuses = {f"{s.address}:{s.port}": s for s in BackendStatus.objects.all()}
+        to_update = []
+        to_add = []
+
         for key, status in backend_to_status_map.items():
-            address, port = key.split(":")
-            try:
-                backend_status = BackendStatus.objects.get(address=address, port=port)
+            backend_status = existing_statuses.get(key)
+            if backend_status:
                 if backend_status.timestamp < self.timestamp:
                     backend_status.status = status
                     backend_status.timestamp = self.timestamp
-                    backend_status.save()
-            except BackendStatus.DoesNotExist:
-                BackendStatus.objects.create(address=address, port=port, status=status, timestamp=self.timestamp)
+                    to_update.append(backend_status)
+            else:
+                address, port = key.split(":")
+                to_add.append(BackendStatus(address=address, port=port, status=status, timestamp=self.timestamp))
+        create_cnt = len(BackendStatus.objects.bulk_create(to_add))
 
-        BackendStatus.objects.filter(timestamp__lt=self.timestamp).delete()
+        # TODO: report number of updated records after updating django to 4.0 or higher
+        BackendStatus.objects.bulk_update(to_update, ['status', 'timestamp'])
+        delete_cnt, _ = BackendStatus.objects.filter(timestamp__lt=self.timestamp).delete()
+        self.logger.info(
+            f"Backend statuses, created: {create_cnt} entries, deleted: {delete_cnt} entries"
+        )
 
     def refresh_statuses(self):
         self.store_backend_statuses(self.load_from_varnish())

--- a/vaas/vaas/monitor/management/commands/backend_statuses.py
+++ b/vaas/vaas/monitor/management/commands/backend_statuses.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from django.core.management.base import BaseCommand
-from vaas.monitor.health import BackendStatusManager
+from vaas.monitor.health import provide_backend_status_manager
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        BackendStatusManager().refresh_statuses()
+        provide_backend_status_manager().refresh_statuses()

--- a/vaas/vaas/monitor/tasks.py
+++ b/vaas/vaas/monitor/tasks.py
@@ -1,8 +1,8 @@
 from django.conf import settings
 from vaas.settings.celery import app
-from vaas.monitor.health import BackendStatusManager
+from vaas.monitor.health import provide_backend_status_manager
 
 
 @app.task(bind=True, soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT_SECONDS)
 def refresh_backend_statuses(self):
-    BackendStatusManager().refresh_statuses()
+    provide_backend_status_manager().refresh_statuses()

--- a/vaas/vaas/monitor/tests/test_health.py
+++ b/vaas/vaas/monitor/tests/test_health.py
@@ -7,17 +7,12 @@ from django.test import TestCase
 from unittest.mock import patch, Mock
 from nose.tools import assert_equals
 
+
 from vaas.monitor.models import BackendStatus
 from vaas.monitor.health import BackendStatusManager
 from vaas.cluster.models import Dc
 from vaas.manager.models import Probe, Backend, Director, TimeProfile
 
-BACKEND_LIST_RAW_RESPONSE_V3 = """Backend name                   Refs   Admin      Probe
-first_service_1_dc1_199_10_80(192.168.199.10,,80) 1      probe      Healthy 5/5
-first_service_2_dc1_199_11_80(192.168.199.11,,80) 1      probe      Sick 5/5
-first_service_3_dc1_199_12_80(192.168.199.12,,80) 1      probe      Healthy 5/5
-deleted_backend_666_dc1_199_99_80(192.168.199.99,,80) 1      probe      Healthy 5/5
-"""
 
 BACKEND_LIST_RAW_RESPONSE_V4_1 = """Backend name                   Admin      Probe
 vagrant_template_4-20160420_13_01_31-vol_6a200.first_service_1_dc1_199_10_80 probe      Healthy 5/5
@@ -26,9 +21,33 @@ vagrant_template_4-20160420_13_01_31-vol_6a200.first_service_3_dc1_199_12_80 pro
 vagrant_template_4-20160420_13_01_31-vol_6a200.deleted_backend_666_dc1_199_99_80 probe      Healthy 5/5
 """
 
-EXPECTED_BACKEND_TO_STATUS_MAP = {'192.168.199.10:80': 'Healthy',
-                                  '192.168.199.11:80': 'Sick',
-                                  '192.168.199.12:80': 'Healthy'}
+BACKEND_LIST_RAW_RESPONSE_V6 = """
+Backend name                   Admin      Probe                Last updated
+template_4-ts-vol_1021a.first_service_2_dc1_199_11_80 probe      Healthy             5/5 Mon, 11 Apr 2022 16:03:08 GMT
+template_4-ts-vol_1021a.first_service_3_dc1_199_12_80 probe      Sick             0/5 Mon, 11 Apr 2022 16:03:08 GMT
+template_4-ts-vol_1021a.first_service_4_dc1_199_13_80 probe      Healthy             5/5 Mon, 11 Apr 2022 16:03:08 GM
+template_4-ts-vol_1021a.del_backend_666_dc1_199_99_80 probe      Healthy             5/5 Mon, 11 Apr 2022 16:03:08 GMT
+"""
+
+
+EXPECTED_BACKEND_TO_STATUS_MAP_V4 = {
+    '192.168.199.10:80': 'Healthy',
+    '192.168.199.11:80': 'Sick',
+    '192.168.199.12:80': 'Healthy'
+}
+
+EXPECTED_BACKEND_TO_STATUS_MAP_V6 = {
+    '192.168.199.11:80': 'Healthy',
+    '192.168.199.12:80': 'Sick',
+    '192.168.199.13:80': 'Healthy'
+}
+
+EXPECTED_MERGED_STATUS_MAP = {
+    '192.168.199.10:80': 'Healthy',
+    '192.168.199.11:80': 'Sick',
+    '192.168.199.12:80': 'Sick',
+    '192.168.199.13:80': 'Healthy'
+}
 
 
 class BackendStatusManagerTest(TestCase):
@@ -45,6 +64,7 @@ class BackendStatusManagerTest(TestCase):
         Backend.objects.create(address='192.168.199.10', port=80, director=director, dc=dc, id=1)
         Backend.objects.create(address='192.168.199.11', port=80, director=director, dc=dc, id=2)
         Backend.objects.create(address='192.168.199.12', port=80, director=director, dc=dc, id=3)
+        Backend.objects.create(address='192.168.199.13', port=80, director=director, dc=dc, id=4)
         BackendStatus.objects.create(address='192.168.199.10', port=80, status='Healthy', timestamp=timestamp)
         BackendStatus.objects.create(address='192.168.199.11', port=80, status='Sick', timestamp=timestamp)
         BackendStatus.objects.create(address='192.168.199.12', port=80, status='Healthy', timestamp=timestamp)
@@ -59,33 +79,51 @@ class BackendStatusManagerTest(TestCase):
             '192.168.199.11:80': 'Sick',
             '192.168.199.12:80': 'Healthy'
         }
-        BackendStatusManager().store_backend_statuses(backend_to_status_map)
+        BackendStatusManager(Mock(), []).store_backend_statuses(backend_to_status_map)
         statuses = BackendStatus.objects.all()
         assert_equals(2, len(statuses))
         self.assert_status('192.168.199.11', 80, 'Sick', statuses[0])
         self.assert_status('192.168.199.12', 80, 'Healthy', statuses[1])
 
-    def test_should_load_backend_statuses_from_varnish_3(self):
+    def test_should_load_backend_statuses_from_varnish_4(self):
+        self._generic_load_backend_statuses_from_varnish(
+            BACKEND_LIST_RAW_RESPONSE_V4_1, EXPECTED_BACKEND_TO_STATUS_MAP_V4
+        )
 
+    def test_should_load_backend_statuses_from_varnish_6(self):
+        self._generic_load_backend_statuses_from_varnish(
+            BACKEND_LIST_RAW_RESPONSE_V6, EXPECTED_BACKEND_TO_STATUS_MAP_V6
+        )
+
+    def _generic_load_backend_statuses_from_varnish(self, backend_list_response, expected_result):
+        timeout = 0.1
+        varnish_server_mock = Mock()
         varnish_api_mock = Mock()
-        varnish_api_mock.fetch.return_value = (None, BACKEND_LIST_RAW_RESPONSE_V3)
+        varnish_api_mock.fetch.return_value = (None, backend_list_response)
 
         varnish_api_provider_mock = Mock()
-        varnish_api_provider_mock.get_connected_varnish_api.return_value = iter([varnish_api_mock])
+        varnish_api_provider_mock.get_api.return_value = varnish_api_mock
 
-        with patch('vaas.monitor.health.VarnishApiProvider', return_value=varnish_api_provider_mock):
-            assert_equals(EXPECTED_BACKEND_TO_STATUS_MAP, BackendStatusManager().load_from_varnish())
+        assert_equals(
+            expected_result,
+            BackendStatusManager(varnish_api_provider_mock, [varnish_server_mock], timeout).load_from_varnish()
+        )
+        varnish_api_provider_mock.get_api.assert_called_once_with(varnish_server_mock, timeout)
 
-    def test_should_load_backend_statuses_from_varnish_4_1(self):
-
-        varnish_api_mock = Mock()
-        varnish_api_mock.fetch.return_value = (None, BACKEND_LIST_RAW_RESPONSE_V4_1)
+    def test_should_merge_backend_statuses_from_multiple_varnishes(self):
+        timeout = 0.1
+        servers = {
+            'first': Mock(fetch=Mock(return_value=(None, BACKEND_LIST_RAW_RESPONSE_V4_1))),
+            'second': Mock(fetch=Mock(return_value=(None, BACKEND_LIST_RAW_RESPONSE_V6)))
+        }
 
         varnish_api_provider_mock = Mock()
-        varnish_api_provider_mock.get_connected_varnish_api.return_value = iter([varnish_api_mock])
+        varnish_api_provider_mock.get_api = Mock(side_effect=lambda s, _: servers[s])
 
-        with patch('vaas.monitor.health.VarnishApiProvider', return_value=varnish_api_provider_mock):
-            assert_equals(EXPECTED_BACKEND_TO_STATUS_MAP, BackendStatusManager().load_from_varnish())
+        assert_equals(
+            EXPECTED_MERGED_STATUS_MAP,
+            BackendStatusManager(varnish_api_provider_mock, servers.keys(), timeout).load_from_varnish()
+        )
 
     def test_should_refresh_backend_statuses(self):
         backend_to_status_map = {
@@ -93,7 +131,7 @@ class BackendStatusManagerTest(TestCase):
             '192.168.199.12:80': 'Healthy'
         }
         with patch('vaas.monitor.health.BackendStatusManager.load_from_varnish', return_value=backend_to_status_map):
-            BackendStatusManager().refresh_statuses()
+            BackendStatusManager(Mock(), []).refresh_statuses()
             statuses = BackendStatus.objects.all()
             assert_equals(2, len(statuses))
             self.assert_status('192.168.199.11', 80, 'Sick', statuses[0])

--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -156,6 +156,8 @@ LOGGING = {
 
 VAAS_LOADER_MAX_WORKERS = 30
 VAAS_RENDERER_MAX_WORKERS = 30
+VAAS_GATHER_STATUSES_MAX_WORKERS = 50
+VAAS_GATHER_STATUSES_CONNECT_TIMEOUT = 0.1
 
 REFRESH_TRIGGERS_CLASS = (
     'Probe', 'Backend', 'Director', 'VarnishServer', 'VclTemplate', 'VclTemplateBlock', 'TimeProfile', 'VclVariable',


### PR DESCRIPTION
The main aim of this change is to provide a more efficient approach to gather & store backend statuses. It has been achieved by:
- using a thread pool to connect to varnishes in a parallel manner
- using dedicated *_bulk operations to create & update entries representing backend statuses

By the way, some logic and tests designated to handle unsupported varnish versions were removed.

There is also small optimization (based on previous optimization in API) of rendering backend list in GUI.