### PR TITLE
Fix #388 | [API] Return empty list for route clusters field when clus…

### DIFF
--- a/vaas/vaas/router/api.py
+++ b/vaas/vaas/router/api.py
@@ -75,7 +75,9 @@ class RouteResource(ModelResource):
         return bundle.obj.director.name
 
     def dehydrate_clusters(self, bundle):
-        return list(bundle.obj.clusters.values_list('name', flat=True))
+        if bundle.obj.clusters_in_sync:
+            return []
+        return [list(bundle.obj.clusters.values_list('name', flat=True))]
 
     def save(self, bundle, *args, **kwargs):
         positive_urls = bundle.data.get('positive_urls', [])


### PR DESCRIPTION
…ters_in_sync is set to true