### PR TITLE
Introduction of canary testing for routes

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -6,7 +6,7 @@ python /home/app/vaas/manage.py collectstatic --no-input
 echo "Migrating"
 python /home/app/vaas/manage.py migrate --run-syncdb
 
-echo "Loadind test_data"
+echo "Loading test_data"
 python /home/app/vaas/manage.py loaddata ./vaas/resources/data.yaml
 
 echo "Install the test requirements to allow [manage.py test] to be called within the container"

--- a/docs/quick-start/development.md
+++ b/docs/quick-start/development.md
@@ -21,6 +21,12 @@ To start Vaas you just have to run:
 docker-compose up -d
 ```
 
+If you resume the development after a long break it is recommended to rebuild the environment by:
+
+```bash
+docker-compose up --build -d
+```
+
 Check That Everything Is Working
 ----------------
 To check that the build is working, run `docker-compose ps`. This should give you output similar to the below.

--- a/vaas/vaas/adminext/widgets.py
+++ b/vaas/vaas/adminext/widgets.py
@@ -72,7 +72,9 @@ class ConditionWidget(forms.MultiWidget):
 
     def value_from_datadict(self, data, files, name):
         parts = super(ConditionWidget, self).value_from_datadict(data, files, name)
-        parts[2] = '"{}"'.format(parts[2])
+        # some operators are intended to use with numbers not strings
+        if parts[1] not in ('>', '<'):
+            parts[2] = '"{}"'.format(parts[2])
         return ' '.join(parts)
 
 

--- a/vaas/vaas/router/models.py
+++ b/vaas/vaas/router/models.py
@@ -89,6 +89,8 @@ def provide_route_configuration():
         [
             Operator(operator='==', name='exact'),
             Operator(operator='!=', name='is different'),
+            Operator(operator='>', name='greater'),
+            Operator(operator='<', name='less'),
             Operator(operator='~', name='match'),
             Operator(operator='!~', name='not match'),
         ],

--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -270,3 +270,6 @@ ROUTES_LEFT_CONDITIONS = env.json('ROUTES_LEFT_CONDITIONS', default={
     'req.http.Host': 'Domain_default',
     'req.http.X-Example': 'X-Example_default',
 })
+ROUTES_CANARY_HEADER = env.str('ROUTES_CANARY_HEADER', default='x-canary-random')
+if ROUTES_CANARY_HEADER:
+    ROUTES_LEFT_CONDITIONS[f'std.real(req.http.{ROUTES_CANARY_HEADER},0)'] = 'Canary'

--- a/vaas/vaas/vcl/renderer.py
+++ b/vaas/vaas/vcl/renderer.py
@@ -305,6 +305,8 @@ class VclTagBuilder(object):
             vcl_tag.parameters['mesh_routing'] = self.placeholders['mesh_routing']
         elif tag_name == 'FLEXIBLE_ROUTER':
             vcl_tag.parameters['routes'] = self.placeholders['routes']
+            vcl_tag.parameters['validation_header'] = settings.VALIDATION_HEADER
+            vcl_tag.parameters['canary_header'] = settings.ROUTES_CANARY_HEADER
         elif tag_name == 'TEST_ROUTER':
             vcl_tag.parameters['validation_header'] = settings.VALIDATION_HEADER
 

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/FLEXIBLE_ROUTER.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/FLEXIBLE_ROUTER.tvcl
@@ -1,7 +1,17 @@
 # Flexible ROUTER
+{% if canary_header %}
+    if (req.http.{{ validation_header }} == "1") {
+        set req.http.{{ canary_header }} = 100;
+    } else {
+        set req.http.{{ canary_header }} = std.random(0, 100);
+    }
+{% endif %}
 {% for route in routes %}
     {% if loop.index > 1 %}    else if {% else %}    if {% endif %}({{ route.condition }}) {
         <SET_ROUTE_{{route.id}}/>
     }
 {% endfor %}
 
+{% if canary_header %}
+    unset req.http.{{ canary_header }};
+{% endif %}

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
@@ -336,7 +336,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "c5780", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "dd65e", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -389,11 +389,18 @@ sub vcl_recv {
     }
 
 # Flexible ROUTER
+    if (req.http.x-validation == "1") {
+        set req.http.x-canary-random = 100;
+    } else {
+        set req.http.x-canary-random = std.random(0, 100);
+    }
     if (req.url ~ "^\/flexible") {
         set req.http.X-Route = "1";
         set req.http.x-route-action = "pass";
         call use_director_first_service;
     }
+
+    unset req.http.x-canary-random;
 
 # Test ROUTER
 if (req.http.x-validation == "1") {

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
@@ -101,7 +101,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "f7eee", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "b7244", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -135,6 +135,13 @@ sub vcl_recv {
     }
 
 # Flexible ROUTER
+    if (req.http.x-validation == "1") {
+        set req.http.x-canary-random = 100;
+    } else {
+        set req.http.x-canary-random = std.random(0, 100);
+    }
+
+    unset req.http.x-canary-random;
 
 # Test ROUTER
 if (req.http.x-validation == "1") {

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
@@ -76,7 +76,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "58626", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "157e4", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -110,6 +110,13 @@ sub vcl_recv {
     }
 
 # Flexible ROUTER
+    if (req.http.x-validation == "1") {
+        set req.http.x-canary-random = 100;
+    } else {
+        set req.http.x-canary-random = std.random(0, 100);
+    }
+
+    unset req.http.x-canary-random;
 
 # Test ROUTER
 if (req.http.x-validation == "1") {

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
@@ -363,7 +363,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "f8293", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "c8593", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -416,11 +416,18 @@ sub vcl_recv {
     }
 
 # Flexible ROUTER
+    if (req.http.x-validation == "1") {
+        set req.http.x-canary-random = 100;
+    } else {
+        set req.http.x-canary-random = std.random(0, 100);
+    }
     if (req.url ~ "^\/flexible") {
         set req.http.X-Route = "1";
         set req.http.x-route-action = "pass";
         call use_director_first_service;
     }
+
+    unset req.http.x-canary-random;
 
 # Test ROUTER
 if (req.http.x-validation == "1") {


### PR DESCRIPTION
What has been done:
- adding a new configuration that allows defining a header where the random value for the canary will be stored
- adding new operators "<" ">" for route conditions
- interpreting the values for the above operators as numbers instead of strings
- adding a new left condition based on a mentioned header that allows defining the percentage of traffic that should be handled by the route

resolves #392