### PR TITLE
API Command for checking varnishes connectivity status

### DIFF
--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -149,14 +149,14 @@ To list backends located in specified DC belonging to specified Director:
 
 ### Call connect command for a set of varnishes by passing varnish ids
 
-Important remark: the command id (in the below example: 7110e99e-453a-4078-843a-f6c36dd358d1) passed in url should be uniq
+Important remark: the command id (in the below example: 7110e99e-453a-4078-843a-f6c36dd358d1) passed in url should be uniq.
 The intention of the command is to connect to each requested **active** varnish server and return a varnish version or error in the output map.
 For inactive or maintenance varnishes, the appropriate status will be returned.
 
     curl -X PUT \
     -d '{ "varnish_ids": [2,3]}' \
     -H "Content-Type: application/json" \
-    "http://localhost:3030/api/v0.1/varnish_server/connect-command/7110e99e-453a-4078-843a-f6c36dd358d1?username=admin&api_key=vagrant_api_key"
+    "http://localhost:3030/api/v0.1/varnish_server/connect-command/7110e99e-453a-4078-843a-f6c36dd358d1/?username=admin&api_key=vagrant_api_key"
 
 expected output
 
@@ -173,7 +173,7 @@ expected output
 
 ### Verify command result
 
-    curl "http://localhost:3030/api/v0.1/varnish_server/connect-command/7110e99e-453a-4078-843a-f6c36dd358d1/?username=admin&api_key=vagrant_api_key
+    curl "http://localhost:3030/api/v0.1/varnish_server/connect-command/7110e99e-453a-4078-843a-f6c36dd358d1/?username=admin&api_key=vagrant_api_key"
 expected output
 
     {

--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -8,23 +8,23 @@ Resources
 
 The following resources are available:
 
-|Name                |Description                                                               |Allowed actions               |
-|--------------------|--------------------------------------------------------------------------|------------------------------|
-|*Backend*           |Represents a single node in a service (director)                          |preview, **add, edit, delete**|
-|*Director*          |A Varnish director; may represent a SOA service                           |preview, **add, edit, delete**|
-|*Probe*             |A health check used to determine backend status                           |preview, **add, edit, delete**|
-|*Dc*                |Datacenter                                                                |preview, **add, edit, delete**|
-|*Logical Cluster*   |Cluster of Varnish servers                                                |preview, **add, edit, delete**|
-|*Varnish Servers*   |A Varnish server                                                          |preview, **add, edit, delete**|
-|*VCL Template Block*|A VCL template block                                                      |preview, **add, edit, delete**|
-|*VCL Template*      |A VCL template                                                            |preview, **add, edit, delete**|
-|*Time Profile*      |Default timeouts profile for director                                     |preview, **add, edit, delete**|
-|*Purger*            |Purge object from varnishes from a given cluster                          |                              |
-|*Outdated Server*   |Represents active varnish servers with outdated vcl                       |preview                       |
-|*Task*              |Represents state of reloading task - check [VaaS Request Flow](./flow.md) |preview                       |
-|*Route*             |Represents conditional routing to desired Director                        |preview, **add, edit, delete**|
-|*RouteConfig*       |Represents possible request parameters, operators & actions, which can be used in Routes|preview|
-|*ValidationReport*  |Represents report of positive urls validation which checks if positive urls are handled by desired Routes|preview|
+|Name                |Description                                                               |Allowed actions               | Allowed commands |
+|--------------------|--------------------------------------------------------------------------|------------------------------|------------------|
+|*Backend*           |Represents a single node in a service (director)                          |preview, **add, edit, delete**|                  |
+|*Director*          |A Varnish director; may represent a SOA service                           |preview, **add, edit, delete**|                  |
+|*Probe*             |A health check used to determine backend status                           |preview, **add, edit, delete**|                  |
+|*Dc*                |Datacenter                                                                |preview, **add, edit, delete**|                  |
+|*Logical Cluster*   |Cluster of Varnish servers                                                |preview, **add, edit, delete**| connect-command  |
+|*Varnish Servers*   |A Varnish server                                                          |preview, **add, edit, delete**|                  |
+|*VCL Template Block*|A VCL template block                                                      |preview, **add, edit, delete**|                  |
+|*VCL Template*      |A VCL template                                                            |preview, **add, edit, delete**|                  |
+|*Time Profile*      |Default timeouts profile for director                                     |preview, **add, edit, delete**|                  |
+|*Purger*            |Purge object from varnishes from a given cluster                          |                              |                  |
+|*Outdated Server*   |Represents active varnish servers with outdated vcl                       |preview                       |                  |
+|*Task*              |Represents state of reloading task - check [VaaS Request Flow](./flow.md) |preview                       |                  |
+|*Route*             |Represents conditional routing to desired Director                        |preview, **add, edit, delete**|                  |
+|*RouteConfig*       |Represents possible request parameters, operators & actions, which can be used in Routes|preview|                  |
+|*ValidationReport*  |Represents report of positive urls validation which checks if positive urls are handled by desired Routes|preview|                  |
 
 VaaS resources can be previewed under http://<VaaS instance\>/api/v0.1/?format=json
 
@@ -146,6 +146,48 @@ To list backends located in specified DC belonging to specified Director:
     -d '{ "ip": "172.17.0.7", "hostname": "varnish3", "dc": "/api/v0.1/dc/1/", "port": "6082", "secret": "edcf6c52-6f93-4d0d-82b9-cd74239146b0", "template": "/api/v0.1/vcl_template/1/", "cluster": "/api/v0.1/logical_cluster/1/", "enabled": "True" }' \
     -H "Content-Type: application/json" \
     "http://localhost:3030/api/v0.1/varnish_server/?username=admin&api_key=vagrant_api_key"
+
+### Call connect command for a set of varnishes by passing varnish ids
+
+Important remark: the command id (in the below example: 7110e99e-453a-4078-843a-f6c36dd358d1) passed in url should be uniq
+The intention of the command is to connect to each requested **active** varnish server and return a varnish version or error in the output map.
+For inactive or maintenance varnishes, the appropriate status will be returned.
+
+    curl -X PUT \
+    -d '{ "varnish_ids": [2,3]}' \
+    -H "Content-Type: application/json" \
+    "http://localhost:3030/api/v0.1/varnish_server/connect-command/7110e99e-453a-4078-843a-f6c36dd358d1?username=admin&api_key=vagrant_api_key"
+
+expected output
+
+    {
+      "output": null,
+      "pk": "7110e99e-453a-4078-843a-f6c36dd358d1",
+      "status": "PENDING",
+      "varnish_ids": [
+        2,
+        3
+      ]
+    }
+
+
+### Verify command result
+
+    curl "http://localhost:3030/api/v0.1/varnish_server/connect-command/7110e99e-453a-4078-843a-f6c36dd358d1/?username=admin&api_key=vagrant_api_key
+expected output
+
+    {
+      "output": {
+        "2": "varnish-7.0.3",
+        "3": "varnish-4.1.11"
+      },
+      "pk": "7110e99e-453a-4078-843a-f6c36dd358d1",
+      "status": "SUCCESS",
+      "varnish_ids": [
+        2,
+        3
+      ]
+    }
 
 ### Delete a backend
 

--- a/vaas/vaas/cluster/api.py
+++ b/vaas/vaas/cluster/api.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
+from celery.result import AsyncResult
 from django.db.models import Count
+from django.urls.conf import re_path
 
 from tastypie.resources import ALL_WITH_RELATIONS, Resource, ModelResource
 from tastypie import fields
 from tastypie.authentication import ApiKeyAuthentication
+from tastypie.exceptions import NotFound, ImmediateHttpResponse
+from tastypie.validation import Validation
 
+from vaas.cluster.cluster import connect_command
 from vaas.cluster.coherency import OutdatedServer, OutdatedServerManager
 from vaas.cluster.forms import LogicalCLusterModelForm, DcModelForm, VclTemplateModelForm, VarnishServerModelForm, \
     VclTemplateBlockModelForm
@@ -148,3 +153,88 @@ class VclTemplateBlockResource(ModelResource):
             'name': ['exact'],
             'template': ALL_WITH_RELATIONS
         }
+
+
+class CommandResource:
+    def __init__(self, pk=None, varnish_ids=None, status=None, output=None):
+        self.pk = pk
+        self.id = pk
+        self.varnish_ids = varnish_ids
+        self.status = status
+        self.output = output
+
+    def __repr__(self):
+        return '{}'.format(self.__dict__)
+
+
+class CommandInputValidation(Validation):
+    def is_valid(self, bundle, request=None):
+        errors = {}
+        try:
+            varnishes = [int(varnish_id) for varnish_id in set(bundle.data.get('varnish_ids', []))]
+            assert VarnishServer.objects.filter(pk__in=varnishes).count() == len(varnishes)
+        except:  # noqa
+            errors['varnish_ids'] = 'Provided varnish identifiers are not valid'
+        else:
+            task = AsyncResult(bundle.data['pk'])
+            if task.args and set(task.args[0]) != set(varnishes):
+                errors['__all__'] = 'Command: %s has been already ordered with another varnish_ids set' \
+                                    % bundle.data['pk']
+
+        return errors
+
+
+class ConnectCommandResource(Resource):
+    pk = fields.CharField(attribute='id', readonly=True)
+    varnish_ids = fields.ListField(attribute='varnish_ids')
+    status = fields.CharField(attribute='status', readonly=True, blank=True, null=True)
+    output = fields.DictField(attribute='output', readonly=True, blank=True, null=True)
+
+    class Meta:
+        resource_name = 'connect-command'
+        list_allowed_methods = []
+        detail_allowed_methods = ['put', 'get']
+        authorization = DjangoAuthorization()
+        authentication = VaasMultiAuthentication(ApiKeyAuthentication())
+        validation = CommandInputValidation()
+        fields = ['input', 'status', 'output']
+        include_resource_uri = False
+        always_return_data = True
+
+    def obj_update(self, bundle, **kwargs):
+        bundle.data['pk'] = kwargs['pk']
+        self.run_validation(bundle)
+        raise NotFound()
+
+    def obj_create(self, bundle, **kwargs):
+        bundle.obj = CommandResource(pk=kwargs['pk'])
+        bundle = self.full_hydrate(bundle)
+        task = connect_command.apply_async([bundle.obj.varnish_ids], task_id=bundle.obj.pk)
+        bundle.obj.status = task.status
+        bundle.obj.output = task.result
+        return bundle
+
+    def hydrate_varnish_ids(self, bundle):
+        bundle.obj.varnish_ids = bundle.data['varnish_ids']
+        return bundle
+
+    def obj_get(self, bundle, **kwargs):
+        task = AsyncResult(kwargs['pk'])
+        varnish_ids = []
+        if task.args and len(task.args):
+            varnish_ids = task.args[0]
+        return CommandResource(kwargs['pk'], varnish_ids, task.status, output=task.result)
+
+    def get_object_list(self, request):
+        return []
+
+    def run_validation(self, bundle):
+        self.is_valid(bundle)
+        if bundle.errors:
+            raise ImmediateHttpResponse(response=self.error_response(bundle.request, bundle.errors))
+
+    def prepend_urls(self):
+        return [
+            re_path(r"^varnish_server/(?P<resource_name>%s)/(?P<pk>[\w\d_.-]+)/$" % self._meta.resource_name,
+                    self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+        ]

--- a/vaas/vaas/cluster/api.py
+++ b/vaas/vaas/cluster/api.py
@@ -173,8 +173,12 @@ class CommandInputValidation(Validation):
         try:
             varnishes = [int(varnish_id) for varnish_id in set(bundle.data.get('varnish_ids', []))]
             assert VarnishServer.objects.filter(pk__in=varnishes).count() == len(varnishes)
+        except AssertionError:
+            errors['varnish_ids'] = 'Some of provided varnish identifiers does not exists'
+        except ValueError:
+            errors['varnish_ids'] = 'Unexpected type, identifiers have got to be an integer'
         except:  # noqa
-            errors['varnish_ids'] = 'Provided varnish identifiers are not valid'
+            errors['varnish_ids'] = 'Unexpected value'
         else:
             task = AsyncResult(bundle.data['pk'])
             if task.args and set(task.args[0]) != set(varnishes):

--- a/vaas/vaas/cluster/cluster.py
+++ b/vaas/vaas/cluster/cluster.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from typing import List, Dict
 
 from django.utils import timezone
 from concurrent.futures import ThreadPoolExecutor
@@ -48,7 +49,7 @@ def load_vcl_task(self, emmit_time, cluster_ids):
 
 
 @app.task(bind=True, soft_time_limit=settings.CELERY_TASK_SOFT_TIME_LIMIT_SECONDS)
-def connect_command(self, varnish_ids):
+def connect_command(self, varnish_ids: List[int]) -> Dict[int, str]:
     result = {}
     with ThreadPoolExecutor(max_workers=len(varnish_ids)) as executor:
         future_results = []

--- a/vaas/vaas/cluster/tests/test_api.py
+++ b/vaas/vaas/cluster/tests/test_api.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from vaas.cluster.api import CommandInputValidation
+
+
+class CommandInputValidationTest(TestCase):
+
+    def test_should_return_error_if_varnish_ids_does_not_contain_integers(self):
+        bundle = Mock(data={'varnish_ids': [1, 'not-int']})
+        command_validation = CommandInputValidation()
+        errors = command_validation.is_valid(bundle, None)
+        self.assertDictEqual({'varnish_ids': 'Unexpected type, identifiers have got to be an integer'}, errors)
+
+    @patch('vaas.cluster.api.VarnishServer.objects.filter', Mock(return_value=Mock(count=Mock(return_value=2))))
+    def test_should_return_error_if_varnish_ids_contains_id_that_does_not_exist_in_db(self):
+        bundle = Mock(data={'varnish_ids': [1, 2, 3]})
+        command_validation = CommandInputValidation()
+        errors = command_validation.is_valid(bundle, None)
+        self.assertDictEqual({'varnish_ids': 'Some of provided varnish identifiers does not exists'}, errors)
+
+    @patch('vaas.cluster.api.VarnishServer.objects.filter', Mock(return_value=Mock(count=Mock(return_value=2))))
+    @patch('vaas.cluster.api.AsyncResult', Mock(return_value=Mock(args=[[2, 3]])))
+    def test_should_return_error_if_already_ordered_task_had_different_parameters(self):
+        bundle = Mock(data={'varnish_ids': [1, 2], 'pk': 'task-uuid'})
+        command_validation = CommandInputValidation()
+        errors = command_validation.is_valid(bundle, None)
+        self.assertDictEqual(
+            {'__all__': 'Command: task-uuid has been already ordered with another varnish_ids set'}, errors)
+
+    @patch('vaas.cluster.api.VarnishServer.objects.filter', Mock(return_value=Mock(count=Mock(return_value=2))))
+    @patch('vaas.cluster.api.AsyncResult', Mock(return_value=Mock(args=[[2, 3]])))
+    def test_should_return_no_error_if_already_ordered_task_had_the_same_uniq_set_of_parameters(self):
+        bundle = Mock(data={'varnish_ids': ['3', 2, 2], 'pk': 'task-uuid'})
+        command_validation = CommandInputValidation()
+        errors = command_validation.is_valid(bundle, None)
+        self.assertDictEqual({}, errors)

--- a/vaas/vaas/cluster/tests/test_cluster.py
+++ b/vaas/vaas/cluster/tests/test_cluster.py
@@ -6,8 +6,8 @@ from django.test import TestCase
 
 from vaas.cluster.forms import VclTemplateModelForm
 from vaas.cluster.models import VarnishServer, Dc, LogicalCluster
-from vaas.cluster.cluster import VarnishCluster, ServerExtractor, ParallelRenderer, ParallelLoader, \
-    VarnishApiProvider, VclLoadException
+from vaas.cluster.cluster import connect_command, connect_status, VarnishCluster, ServerExtractor, ParallelRenderer, \
+    ParallelLoader, VarnishApiProvider, VclLoadException
 from vaas.vcl.loader import VclLoader, VclStatus
 from vaas.vcl.renderer import VclRenderer, Vcl
 from vaas.api.client import VarnishApi
@@ -33,6 +33,39 @@ query_set = Mock()
 query_set.prefetch_related = Mock(return_value=servers)
 
 sample_vcl = Vcl('Test-content', name='test')
+
+
+def test_should_return_connection_status_for_active_server():
+    server = VarnishServer(pk=11, ip='127.0.0.1', port='6082', status='active')
+    varnish_api_mock = Mock(daemon_version=Mock(return_value='varnish-7.0.3'))
+
+    with patch.object(VarnishApiProvider, 'get_api', return_value=varnish_api_mock):
+        assert_equals('varnish-7.0.3', connect_status(server))
+
+    varnish_api_mock.daemon_version.assert_called_once()
+
+
+def test_should_return_object_status_for_inactive_server():
+    for inactive_status in ('maintenance', 'disabled',):
+        inactive_server = VarnishServer(pk=11, ip='127.0.0.1', port='6082', status=inactive_status)
+        assert_equals(inactive_status, connect_status(inactive_server))
+
+
+def test_command_should_return_connection_statuses_for_each_server():
+    statuses = {
+        11: 'varnish-7.0.3',
+        12: 'maintenance',
+    }
+    db_servers = [
+        VarnishServer(pk=11),
+        VarnishServer(pk=12)
+    ]
+    with patch('vaas.cluster.cluster.VarnishServer.objects.filter', Mock(return_value=db_servers)):
+        with patch('vaas.cluster.cluster.connect_status', Mock(side_effect=lambda s: statuses[s.pk])):
+            result = connect_command([11, 12])
+            assert_equals(2, len(result))
+            assert_equals('varnish-7.0.3', result[11])
+            assert_equals('maintenance', result[12])
 
 
 class ServerExtractorTest(TestCase):

--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -199,6 +199,7 @@ CELERY_TASK_SOFT_TIME_LIMIT_SECONDS = env.int('CELERY_TASK_SOFT_TIME_LIMIT_SECON
 
 CELERY_ROUTES = {
     'vaas.router.report.fetch_urls_async': {'queue': 'routes_test_queue'},
+    'vaas.cluster.cluster.connect_command': {'queue': 'routes_test_queue'},
     'vaas.monitor.tasks.refresh_backend_statuses': {'queue': 'cron_queue'},
     'vaas.*': {'queue': 'worker_queue'},
 }

--- a/vaas/vaas/settings/celery.py
+++ b/vaas/vaas/settings/celery.py
@@ -9,6 +9,8 @@ app = Celery('vaas')
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings')
+app.conf.update(result_extended=True)
+
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 

--- a/vaas/vaas/urls.py
+++ b/vaas/vaas/urls.py
@@ -5,7 +5,7 @@ from django.contrib.admin.sites import NotRegistered
 from django.views.generic.base import RedirectView
 from tastypie.api import Api
 
-from vaas.cluster.api import DcResource, VarnishServerResource, VclTemplateBlockResource, VclTemplateResource, \
+from vaas.cluster.api import ConnectCommandResource, DcResource, VarnishServerResource, VclTemplateBlockResource, VclTemplateResource, \
     LogicalClusterResource, OutdatedServerResource
 from vaas.manager.api import ProbeResource, DirectorResource, BackendResource, TimeProfileResource, \
     ReloadTaskResource
@@ -40,7 +40,7 @@ v01_api.register(RouteResource())
 v01_api.register(RouteConfigurationResource())
 v01_api.register(ValidateRoutesRequest())
 v01_api.register(ValidationReportResource())
-
+v01_api.register(ConnectCommandResource())
 
 urlpatterns = [
     url(r'^admin/purger/', include('vaas.purger.urls')),

--- a/vaas/vaas/urls.py
+++ b/vaas/vaas/urls.py
@@ -5,8 +5,8 @@ from django.contrib.admin.sites import NotRegistered
 from django.views.generic.base import RedirectView
 from tastypie.api import Api
 
-from vaas.cluster.api import ConnectCommandResource, DcResource, VarnishServerResource, VclTemplateBlockResource, VclTemplateResource, \
-    LogicalClusterResource, OutdatedServerResource
+from vaas.cluster.api import ConnectCommandResource, DcResource, VarnishServerResource, VclTemplateBlockResource, \
+    VclTemplateResource, LogicalClusterResource, OutdatedServerResource
 from vaas.manager.api import ProbeResource, DirectorResource, BackendResource, TimeProfileResource, \
     ReloadTaskResource
 from vaas.router.api import RouteResource, RouteConfigurationResource, ValidateRoutesRequest, ValidationReportResource


### PR DESCRIPTION
This change provides an endpoint that could be useful for lazy loading varnish connectivity statuses. 
It should be helpful to resolve #389 