### PR TITLE
Fix testing canary routes

### DIFF
--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/FLEXIBLE_ROUTER.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/FLEXIBLE_ROUTER.tvcl
@@ -1,7 +1,7 @@
 # Flexible ROUTER
 {% if canary_header %}
     if (req.http.{{ validation_header }} == "1") {
-        set req.http.{{ canary_header }} = 100;
+        set req.http.{{ canary_header }} = 0;
     } else {
         set req.http.{{ canary_header }} = std.random(0, 100);
     }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
@@ -336,7 +336,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "dd65e", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "1059a", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -390,7 +390,7 @@ sub vcl_recv {
 
 # Flexible ROUTER
     if (req.http.x-validation == "1") {
-        set req.http.x-canary-random = 100;
+        set req.http.x-canary-random = 0;
     } else {
         set req.http.x-canary-random = std.random(0, 100);
     }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
@@ -101,7 +101,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "b7244", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "5feca", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -136,7 +136,7 @@ sub vcl_recv {
 
 # Flexible ROUTER
     if (req.http.x-validation == "1") {
-        set req.http.x-canary-random = 100;
+        set req.http.x-canary-random = 0;
     } else {
         set req.http.x-canary-random = std.random(0, 100);
     }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
@@ -76,7 +76,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "157e4", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "51963", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -111,7 +111,7 @@ sub vcl_recv {
 
 # Flexible ROUTER
     if (req.http.x-validation == "1") {
-        set req.http.x-canary-random = 100;
+        set req.http.x-canary-random = 0;
     } else {
         set req.http.x-canary-random = std.random(0, 100);
     }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
@@ -363,7 +363,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "c8593", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "d25f7", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -417,7 +417,7 @@ sub vcl_recv {
 
 # Flexible ROUTER
     if (req.http.x-validation == "1") {
-        set req.http.x-canary-random = 100;
+        set req.http.x-canary-random = 0;
     } else {
         set req.http.x-canary-random = std.random(0, 100);
     }


### PR DESCRIPTION
Setting header x-canary-random=0 during validation to ensure that the condition canary<XX% will be always satisfied