### PR TITLE
Load varnish connection status asynchronously on GUI

### DIFF
--- a/vaas/vaas/adminext/static/utils/js/csrf.js
+++ b/vaas/vaas/adminext/static/utils/js/csrf.js
@@ -1,0 +1,24 @@
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = cookies[i].trim();
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
+function csrfSafeMethod(method) {
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+
+function setCRSFToken(xhr, settings) {
+    if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+        xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+    }
+}

--- a/vaas/vaas/adminext/templates/admin/base.html
+++ b/vaas/vaas/adminext/templates/admin/base.html
@@ -24,6 +24,7 @@
     <script src="{% static "admin/js/jquery-1.9.1.min.js" %}"></script>
     <script src="{% static "admin/js/jquery-migrate-1.2.1.min.js" %}"></script>
     <script src="{% static "bootstrap/js/bootstrap.min.js" %}"></script>
+    <script src="{% static "utils/js/csrf.js" %}"></script>
 
     {% block extrahead %}{% endblock %}
 

--- a/vaas/vaas/cluster/admin.py
+++ b/vaas/vaas/cluster/admin.py
@@ -106,20 +106,13 @@ class VarnishServerAdmin(AuditableModelAdmin):
 
     def is_connected(self, obj):
         if obj.status == 'active':
-            try:
-                api = self.varnish_api_provider.get_api(obj)
-                version = api.daemon_version()
-                return format_html(
-                    "<div class='span13 text-center'>"
-                    "<a class='btn btn-xs btn-success' href='#'>" + version + "</a>"
-                    "</div>"
-                )
-            except:  # noqa
-                return format_html(
-                    "<div class='span13 text-center'>"
-                    "<a class='btn btn-xs btn-danger' href='#'><i class='glyphicon glyphicon-off'></i></a>"
-                    "</div>"
-                )
+            return format_html(
+                "<div class='span13 text-center'>"
+                "<a class='btn btn-xs' data-varnish-id='" + str(obj.pk) + "' href='#'>"
+                "<i class='glyphicon loader'></i>"
+                "</a>"
+                "</div>"
+            )
         elif obj.status == 'maintenance':
             return format_html(
                 "<div class='span13 text-center'>"

--- a/vaas/vaas/cluster/api.py
+++ b/vaas/vaas/cluster/api.py
@@ -8,7 +8,7 @@ from django.urls.conf import re_path
 
 from tastypie.resources import ALL_WITH_RELATIONS, Resource, ModelResource
 from tastypie import fields
-from tastypie.authentication import ApiKeyAuthentication
+from tastypie.authentication import ApiKeyAuthentication, SessionAuthentication
 from tastypie.exceptions import NotFound, ImmediateHttpResponse
 from tastypie.validation import Validation
 
@@ -207,7 +207,7 @@ class ConnectCommandResource(Resource):
         list_allowed_methods = []
         detail_allowed_methods = ['put', 'get']
         authorization = DjangoAuthorization()
-        authentication = VaasMultiAuthentication(ApiKeyAuthentication())
+        authentication = VaasMultiAuthentication(ApiKeyAuthentication(), SessionAuthentication())
         validation = CommandInputValidation()
         fields = ['input', 'status', 'output']
         include_resource_uri = False

--- a/vaas/vaas/manager/templates/cluster/admin_app_varnishserver_description.html
+++ b/vaas/vaas/manager/templates/cluster/admin_app_varnishserver_description.html
@@ -1,6 +1,27 @@
 <!-- Modal -->
+<style>
+  .loader {
+    border: 10px solid #f3f3f3;
+    border-radius: 50%;
+    border-top: 10px solid #555;
+    -webkit-animation: spin 1s linear infinite;
+    animation: spin 1s linear infinite;
+  }
+
+  @-webkit-keyframes spin {
+    0% { -webkit-transform: rotate(0deg); }
+    100% { -webkit-transform: rotate(360deg); }
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+</style>
 <script>
+    var task_status = '';
     $(document).ready(function () {
+        var command_url = '/api/v0.1/varnish_server/connect-command/' + Date.now().toString(36) + Math.random().toString(36).substring(2) + '/';
         var vcl_modal = $('#vclModal');
         vcl_modal.on('show.bs.modal', function (event) {
             var vcl = $(event.relatedTarget).data('vcl');
@@ -9,8 +30,72 @@
         vcl_modal.on('hidden.bs.modal', function (e) {
             $(this).find('.modal-body').empty();
         });
+        connectCommand([2,], command_url);
+    });
 
-    })
+    function handleError(request, textStatus, errorThrown) {
+        console.error(textStatus, errorThrown)
+    }
+    function connectCommand(servers, url) {
+        return $.ajax({
+          type: 'PUT',
+          url: url,
+          data: JSON.stringify({'varnish_ids': findServers()}),
+          dataType: 'json',
+          contentType: "application/json; charset=utf-8",
+          error: handleError,
+          success: handleCommandResponse,
+          beforeSend: setCRSFToken,
+          complete: function () { if (task_status != 'done') { setTimeout(function () { poolCommandResult(url) }, 500) } },
+        });
+    }
+
+    function poolCommandResult(url) {
+        $.ajax({
+          url: url,
+          dataType: 'json',
+          error: handleError,
+          success: handleCommandResponse,
+          complete: function () { if (task_status != 'done') { setTimeout(function () { poolCommandResult(url) }, 500) } },
+          timeout: 5000
+        });
+    }
+
+    function handleCommandResponse(data, textStatus, request) {
+        const status = data.status
+        if (status === 'FAILURE') {
+          task_status = 'done';
+          $('[data-varnish-id]').each(function(index) {
+            $(this).addClass('btn-info')
+            $(this).children('i').removeClass('loader').addClass('glyphicon-remove')
+          })
+        }
+        else if (status === 'SUCCESS') {
+          task_status = 'done';
+          $('[data-varnish-id]').each(function(index) {
+            if ($(this).data('varnish-id') in data.output) {
+                var result = data.output[$(this).data('varnish-id')];
+                if (result !== 'error') {
+                    $(this).addClass('btn-success')
+                    $(this).children('i').remove()
+                    $(this).text(result)
+                } else {
+                    $(this).addClass('btn-danger')
+                    $(this).children('i').removeClass('loader').addClass('glyphicon-off')
+                }
+            }
+            $(this).addClass('btn-secondary')
+            $(this).children('i').removeClass('loader').addClass('glyphicon-remove')
+          })
+        }
+    }
+    function findServers() {
+        var result = [];
+        $('[data-varnish-id]').each(function(index) {
+            result.push($(this).data('varnish-id'));
+        })
+        return result;
+    }
 </script>
 <div class="modal fade" id="vclModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">

--- a/vaas/vaas/manager/templates/router/admin_app_route_description.html
+++ b/vaas/vaas/manager/templates/router/admin_app_route_description.html
@@ -23,24 +23,6 @@
 <script>
   var taskURL = '';
   const noDataPlaceholder = { name: 'no data', id: 'no data' };
-  const csrfToken = getCookie('csrftoken');
-  function getCookie(name) {
-    var cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-      var cookies = document.cookie.split(';');
-      for (var i = 0; i < cookies.length; i++) {
-        var cookie = cookies[i].trim();
-        if (cookie.substring(0, name.length + 1) === (name + '=')) {
-          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-          break;
-        }
-      }
-    }
-    return cookieValue;
-  }
-  function csrfSafeMethod(method) {
-    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-  }
   function handleError(request, textStatus, errorThrown) {
     $('#spinner').hide()
     console.error(textStatus, errorThrown)
@@ -54,11 +36,7 @@
       dataType: 'json',
       contentType: "application/json; charset=utf-8",
       error: handleError,
-      beforeSend: function (xhr, settings) {
-        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-          xhr.setRequestHeader("X-CSRFToken", csrfToken);
-        }
-      },
+      beforeSend: setCRSFToken,
       success: callback,
     });
   }

--- a/vaas/vaas/resources/data.yaml
+++ b/vaas/vaas/resources/data.yaml
@@ -122,10 +122,10 @@
     clusters: [2]
 - model: router.positiveurl
   pk: 1
-  fields: {url: http://192.168.1.4:6081/flexibleee, route: 1}
+  fields: {url: http://192.168.199.4:6081/flexibleee, route: 1}
 - model: router.positiveurl
   pk: 2
-  fields: {url: http://192.168.1.4:6081/wrong, route: 1}
+  fields: {url: http://192.168.199.4:6081/wrong, route: 1}
 - model: auth.user
   fields:
     password: pbkdf2_sha256$36000$HSNx3yHNXG51$yggojN+90XWiHuGBK7YnrUZMWtMKpck45CsSel0JxUk=


### PR DESCRIPTION
What has been done:
- changed content generation of the connection column on the varnish servers view
- added csrf.js to extract csrf token from cookie and add it to ajax requests
- added logic for order connect-command via ajax for displayed varnish servers
- the same csrf logic has been used for ordering route validation report
- fixed route example positive URLs to point to existing servers

Solve #389 