### PR TITLE
Fix partial reload behavior

### DIFF
--- a/vaas/vaas/cluster/admin.py
+++ b/vaas/vaas/cluster/admin.py
@@ -169,6 +169,7 @@ class VclTemplateBlockAdmin(SimpleHistoryAdmin):
 
 class VclTemplateAdmin(SimpleHistoryAdmin, AuditableModelAdmin):
     form = VclTemplateModelForm
+    search_fields = ['name']
     formfield_overrides = {
         models.TextField: {'widget': ace_widget},
     }
@@ -178,9 +179,11 @@ class VclTemplateAdmin(SimpleHistoryAdmin, AuditableModelAdmin):
 
 class LogicalClusterAdmin(admin.ModelAdmin):
     form = LogicalCLusterModelForm
+    search_fields = ['name', 'labels']
     list_display = [
         'name',
         'service_mesh_routing',
+        'partial_reload',
         'reload_timestamp',
         'error_timestamp',
         'last_error_info',

--- a/vaas/vaas/cluster/tests/test_cluster.py
+++ b/vaas/vaas/cluster/tests/test_cluster.py
@@ -10,7 +10,7 @@ from vaas.cluster.cluster import connect_command, connect_status, validate_vcl_c
     ServerExtractor, ParallelRenderer, ParallelLoader, VarnishApiProvider, VclLoadException
 from vaas.vcl.loader import VclLoader, VclStatus
 from vaas.vcl.renderer import Vcl
-from vaas.api.client import VarnishApi
+from vaas.api.client import VarnishApi, VarnishApiReadException
 
 dc = Dc(name='Tokyo', symbol='dc2')
 cluster1 = LogicalCluster(name='cluster1', id=1)
@@ -218,11 +218,20 @@ class ParallelLoaderTest(TestCase):
                 ParallelLoader().load_vcl_list(vcl_list)
 
     @raises(VclLoadException)
-    def test_should_raise_custom_exception_if_error_occurred_while_connecting_to_server(self):
+    def test_should_raise_custom_exception_if_timeout_occurred_while_loading_vcl(self):
         first_vcl = Vcl('Test-1', name='test-1')
         vcl_list = [(servers[1], first_vcl)]
 
         with patch.object(VarnishApiProvider, 'get_api'):
+            with patch.object(VclLoader, 'load_new_vcl', side_effect=VarnishApiReadException):
+                ParallelLoader().load_vcl_list(vcl_list)
+
+    @raises(VclLoadException)
+    def test_should_raise_custom_exception_if_error_occurred_while_connecting_to_server(self):
+        first_vcl = Vcl('Test-1', name='test-1')
+        vcl_list = [(servers[1], first_vcl)]
+
+        with patch.object(VarnishApi, '__init__', side_effect=Exception):
             ParallelLoader().load_vcl_list(vcl_list)
 
     def assert_loaded_vcl_contains_proper_vcl_and_server(self, loaded_vcl_tuple, expected_vcl, expected_server):
@@ -276,6 +285,24 @@ class ParallelLoaderTest(TestCase):
             with patch.object(VclLoader, 'load_new_vcl', return_value=VclStatus.OK):
                 # as opposed to test:
                 # test_should_raise_custom_exception_if_error_occurred_while_connecting_to_server
+                # it DOES NOT raise any exception when cluster allow partial reloads
+                # what is being tested implicitly there.
+                to_use = ParallelLoader().load_vcl_list(vcl_list)
+                assert_equals(len(to_use), 1)
+
+    def test_should_return_vcl_list_without_servers_that_have_timed_out_while_loading_vcl(self):
+        first_vcl = Vcl('Test-1', name='test-1')
+        second_vcl = Vcl('Test-2', name='test-2')
+        cluster_with_partial_reload = LogicalCluster(name='cluster1', id=1, partial_reload=True)
+        server = VarnishServer(ip='127.0.0.1', port='6082', hostname='localhost-1', secret='secret-1', dc=dc,
+                               cluster=cluster_with_partial_reload, status='active')
+
+        vcl_list = [(server, first_vcl), (servers[1], second_vcl)]
+
+        with patch.object(VarnishApiProvider, 'get_api'):
+            with patch.object(VclLoader, 'load_new_vcl', side_effect=[VarnishApiReadException, VclStatus.OK]):
+                # as opposed to test:
+                # test_should_raise_custom_exception_if_timeout_occurred_while_loading_vcl
                 # it DOES NOT raise any exception when cluster allow partial reloads
                 # what is being tested implicitly there.
                 to_use = ParallelLoader().load_vcl_list(vcl_list)


### PR DESCRIPTION
What has been done:
- raising VclLoadException on a timeout during reloading VCL
- do not raise an exception if timed out cluster belongs to a logical cluster with enabled partial reload
- adding partial reload column to logical cluster view
- adding search feature for admin views: logical cluster, vcl template