### PR TITLE
vcl compilation check

### DIFF
--- a/vaas/vaas/adminext/static/cluster/js/vcl-validation.js
+++ b/vaas/vaas/adminext/static/cluster/js/vcl-validation.js
@@ -1,0 +1,117 @@
+$(document).ready(function () {
+    // check if contains container fo validation
+    if ($('#validation-modal').length > 0) {
+        // add validate button only for change form, we can recognize that by delete button
+        if ($('.form-actions .pull-left').children().length > 0) {
+            var templateId = parseTemplateId()
+            $('.form-actions .pull-right').prepend('<button class="btn btn-warning" name="_vcl_validate">Compile vcl</button>');
+            $("[name=_vcl_validate]").click(function (event) {
+                var commandId = Date.now().toString(36) + Math.random().toString(36).substring(2);
+                event.preventDefault();
+                clearModal(commandId);
+                vclValidateCommand(
+                    $('textarea[name=content]').val(),
+                    '/api/v0.1/vcl_template/' + templateId + '/vcl-validate-command/' + commandId + '/'
+                );
+            });
+        }
+    }
+})
+
+function clearModal(commandId) {
+    $('#spinner').show();
+    $('#result').hide();
+    $('#command-status').removeClass();
+    $('#command-status').addClass(`label label-default`).text("unknown");
+    $('#command-result').removeClass();
+    $('#command-result').addClass(`label label-default`).text("UNKNOWN");
+    $('#validation-modal').modal('show');
+    $('#command-id').text(commandId);
+    $('#command-id').data("status", "started");
+}
+
+function parseTemplateId() {
+    var linkParts = $('.deletelink').attr('href').split('/')
+    return linkParts[linkParts.length - 3]
+}
+
+function vclValidateCommand(content, url) {
+    return $.ajax({
+      type: 'PUT',
+      url: url,
+      data: JSON.stringify({'content': content}),
+      dataType: 'json',
+      contentType: "application/json; charset=utf-8",
+      error: handleErrorResponse,
+      success: handleVclValidateResponse,
+      beforeSend: setCRSFToken,
+      complete: function () { if (isResultStillAwaited(url)) { setTimeout(function () { poolVclValidateResult(url) }, 500) } },
+    });
+}
+
+function poolVclValidateResult(url) {
+    $.ajax({
+      url: url,
+      dataType: 'json',
+      error: handleErrorResponse,
+      success: handleVclValidateResponse,
+      complete: function () { if (isResultStillAwaited(url)) { setTimeout(function () { poolVclValidateResult(url) }, 500) } },
+      timeout: 5000
+    });
+}
+
+function handleErrorResponse(request, textStatus, errorThrown) {
+    setCommandStatus('done');
+    console.error(textStatus, errorThrown)
+    $('#command-result').addClass(`label-${statusToClass(validationStatus(false))}`).text(validationStatus('Error'));
+    $('#error-type').text('Validation error')
+    $('#error-message').text(request.responseText)
+    $('#result').show();
+    $('#spinner').hide();
+    $('#command-status').addClass(`label label-${statusToClass(status)}`).text('error');
+}
+
+function handleVclValidateResponse(data, textStatus, request) {
+    const status = data.status
+    if (checkCommandStatus(data.pk, 'done')) return;
+    if (status === 'FAILURE') {
+      setCommandStatus('done');
+      $('#spinner').hide()
+    }
+    else if (status === 'SUCCESS') {
+      setCommandStatus('done');
+      $('#servers-no').text(data.output.servers_num);
+      $('#command-result').addClass(`label-${statusToClass(validationStatus(data.output.is_valid))}`).text(validationStatus(data.output.is_valid));
+      if (!data.output.is_valid) {
+        $('#error-type').text(data.output.error.type)
+        $('#error-message').text(data.output.error.message)
+        $('#result').show();
+      }
+      $('#spinner').hide()
+    }
+    $('#command-status').addClass(`label label-${statusToClass(status)}`).text(status);
+}
+
+function validationStatus(status) {
+    if (status) {
+        return 'SUCCESS';
+    }
+    return 'FAIL';
+}
+
+function checkCommandStatus(status) {
+    return $('#command-id').data('status') == status
+}
+
+function setCommandStatus(status) {
+    $('#command-id').data('status', status)
+}
+
+function isPollingFinished(commandId, status) {
+    return $('#command-id').text() != commandId || checkCommandStatus('done')
+}
+
+function isResultStillAwaited(commandURL) {
+    var parts = commandURL.split('/')
+    return !isPollingFinished(parts[parts.length-2], 'done');
+}

--- a/vaas/vaas/adminext/static/utils/js/labels.js
+++ b/vaas/vaas/adminext/static/utils/js/labels.js
@@ -1,0 +1,14 @@
+function statusToClass(status) {
+    switch (status) {
+      case 'PENDING':
+        return 'info';
+      case 'PASS':
+      case 'SUCCESS':
+        return 'success'
+      case 'FAIL':
+      case 'FAILURE':
+        return 'danger'
+      default:
+        return 'default'
+    }
+}

--- a/vaas/vaas/adminext/templates/admin/cluster/change_form.html
+++ b/vaas/vaas/adminext/templates/admin/cluster/change_form.html
@@ -1,0 +1,59 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block submit_buttons_bottom %}
+{% submit_row %}
+<style>
+  .loader {
+    border: 5px solid #f3f3f3;
+    border-radius: 50%;
+    border-top: 5px solid #555;
+    width: 50px;
+    height: 50px;
+    -webkit-animation: spin 1s linear infinite;
+    animation: spin 1s linear infinite;
+  }
+
+  @-webkit-keyframes spin {
+    0% { -webkit-transform: rotate(0deg); }
+    100% { -webkit-transform: rotate(360deg); }
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+</style>
+<div class="modal fade" id="validation-modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document" style="width: 80%;">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+            aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">Checking vcl compilation result</h4>
+      </div>
+      <div class="modal-body">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Task info</h3>
+          </div>
+          <div class="panel-body">
+            <h5>Command status: <span id="command-status" class="label label-default">unknown</span></h5>
+            <h5>Command ID: <span id="command-id" class="label label-default"></span></h5>
+            <h5>Affected servers: <span id="servers-no" class="label label-default">0</span></h5>
+          </div>
+        </div>
+        <h2>Compilation status: <span id="command-result" class="label label-default">UNKNOWN</span></h2>
+        <div id="spinner" class="loader center-block"></div>
+        <div id="result" class="alert alert-danger">
+          <h4 id="error-type"></h4>
+          <pre id="error-message"></pre>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/vaas/vaas/cluster/api.py
+++ b/vaas/vaas/cluster/api.py
@@ -300,7 +300,7 @@ class ValidateVCLCommandResource(Resource):
         list_allowed_methods = []
         detail_allowed_methods = ['put', 'get']
         authorization = DjangoAuthorization()
-        authentication = VaasMultiAuthentication(ApiKeyAuthentication())
+        authentication = VaasMultiAuthentication(ApiKeyAuthentication(), SessionAuthentication())
         validation = ValidateVCLCommandInputValidation()
         fields = ['content', 'status', 'output']
         include_resource_uri = False

--- a/vaas/vaas/cluster/cluster.py
+++ b/vaas/vaas/cluster/cluster.py
@@ -302,7 +302,9 @@ class ParallelLoader(ParallelExecutor):
     def _discard_from_future(self, executor, future_results):
         discard_results = []
         for vcl, loader, server, future_result in future_results:
-            self._discard_unused_vcls(server, loader, executor, discard_results)
+            result = self._get_load_new_vcl_result(server, future_result)
+            if result == VclStatus.OK:
+                self._discard_unused_vcls(server, loader, executor, discard_results)
         for server, status in discard_results:
             if status.result() is VclStatus.ERROR:
                 self.logger.debug("ERROR while discard vcl's on %s" % (server))

--- a/vaas/vaas/cluster/forms.py
+++ b/vaas/vaas/cluster/forms.py
@@ -28,6 +28,9 @@ class VclTemplateModelForm(ModelForm):
         model = VclTemplate
         fields = '__all__'
 
+    class Media:
+        js = ('cluster/js/vcl-validation.js', 'utils/js/labels.js',)
+
 
 class VarnishServerModelForm(ModelForm):
     def __init__(self, *args, **kwargs):

--- a/vaas/vaas/manager/templates/cluster/admin_app_varnishserver_description.html
+++ b/vaas/vaas/manager/templates/cluster/admin_app_varnishserver_description.html
@@ -30,7 +30,7 @@
         vcl_modal.on('hidden.bs.modal', function (e) {
             $(this).find('.modal-body').empty();
         });
-        connectCommand([2,], command_url);
+        connectCommand(findServers(), command_url);
     });
 
     function handleError(request, textStatus, errorThrown) {
@@ -40,7 +40,7 @@
         return $.ajax({
           type: 'PUT',
           url: url,
-          data: JSON.stringify({'varnish_ids': findServers()}),
+          data: JSON.stringify({'varnish_ids': servers}),
           dataType: 'json',
           contentType: "application/json; charset=utf-8",
           error: handleError,

--- a/vaas/vaas/manager/templates/router/admin_app_route_description.html
+++ b/vaas/vaas/manager/templates/router/admin_app_route_description.html
@@ -74,20 +74,6 @@
     $('#error-message').remove()
     $('.modal-body').prepend(`<div id="error-message" class="alert alert-danger" role="alert">${message}</div>`)
   }
-  function statusToClass(status) {
-    switch (status) {
-      case 'PENDING':
-        return 'info';
-      case 'PASS':
-      case 'SUCCESS':
-        return 'success'
-      case 'FAIL':
-      case 'FAILURE':
-        return 'danger'
-      default:
-        return 'default'
-    }
-  }
   function createTestResult(records) {
     var html = '';
     records.sort(function(x, y) {

--- a/vaas/vaas/router/admin.py
+++ b/vaas/vaas/router/admin.py
@@ -26,7 +26,7 @@ class RouteAdmin(AuditableModelAdmin):
         return super().changelist_view(request, extra_context=ctx)
 
     class Media:
-        js = ('js/clusters-sync.js',)
+        js = ('js/clusters-sync.js', 'utils/js/labels.js')
 
 
 admin.site.register(Route, RouteAdmin)


### PR DESCRIPTION
What has been done:
- added a new button in the vcl template edit form: Compile vcl
![Zrzut ekranu 2022-11-28 o 14 39 33](https://user-images.githubusercontent.com/4157902/204294992-9f047f60-33e1-4916-895a-bdb8d443d784.png)
- JS logic for ordering and polling vcl-validate-command
- added dialog box that presents compilation status/failure
![Zrzut ekranu 2022-11-28 o 14 39 42](https://user-images.githubusercontent.com/4157902/204295621-25720c0d-fe3e-4dd0-8713-bca87caff314.png)
- fixing discarding logic (discards are ordered only on servers that previously properly loaded a VCL)

Fix #419 