### PR TITLE
Add vcl snippet for testing redirects + bunch of fixes

### DIFF
--- a/vaas/vaas/manager/signals.py
+++ b/vaas/vaas/manager/signals.py
@@ -13,7 +13,6 @@ from vaas.cluster.models import VarnishServer, VclTemplate, VclTemplateBlock, Vc
 from vaas.router.models import Redirect, Route
 from vaas.manager.middleware import VclRefreshState
 from vaas.manager.models import Director, Backend, Probe, TimeProfile
-from vaas.cluster.models import DomainMapping
 
 
 def switch_state_and_reload(queryset, enabled):

--- a/vaas/vaas/resources/data.yaml
+++ b/vaas/vaas/resources/data.yaml
@@ -78,7 +78,7 @@
   pk: 1
   fields: {name: cluster1_siteA_test, reload_timestamp: '2019-11-19T08:02:15.994071+00:00',
     error_timestamp: '2019-11-13T07:46:40.450785+00:00', last_error_info: null,
-           current_vcl_versions: '[]', labels_list: '["placeholder:cluster1"]'}
+           current_vcl_versions: '[]', labels_list: '["placeholder:192.168.199.6"]'}
 - model: cluster.logicalcluster
   pk: 2
   fields: {name: cluster2_siteB_test, reload_timestamp: '2019-11-18T14:16:58.664933+00:00',
@@ -96,10 +96,12 @@
             current_vcl_versions: '[]', labels_list: '["placeholder:cluster4"]'}
 - model: cluster.domainmapping
   pk: 1
-  fields: {domain: "mydomain.com", mapping: "mydomain.base{{ placeholder }}.com",
-    type: static, clusters: [1]}
+  fields: {domain: "mydomain.com", mapping: "{{ placeholder }}:6081", type: dynamic, clusters: [1]}
 - model: cluster.domainmapping
   pk: 2
+  fields: {domain: "192.168.199.6:6081", mapping: "192.168.199.6:6081", type: static, clusters: [1]}
+- model: cluster.domainmapping
+  pk: 3
   fields: {domain: "example.com", mapping: "example.base.com", type: static, clusters: [3]}
 - model: cluster.vcltemplate
   pk: 2

--- a/vaas/vaas/router/api.py
+++ b/vaas/vaas/router/api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Any, Dict, List
+from typing import Any, List
 
 from celery.result import AsyncResult
 from django.urls import re_path
@@ -69,7 +69,6 @@ class RedirectResource(ModelResource):
             redirect.assertions.bulk_create(to_add)
         if len(to_delete):
             redirect.assertions.filter(pk__in=to_delete.values()).delete()
-
 
     # If PATCH request not contains redirect_assertions field,
     # tastypie pulls out Bundle object with rewrite_positive_urls currently attached to the Redirect object
@@ -317,10 +316,6 @@ class ValidateRedirectsCommandResource(Resource):
         bundle.obj.output = task.result
         return bundle
 
-    def obj_update(self, bundle, **kwargs):
-        bundle.data['pk'] = kwargs['pk']
-        raise NotFound()
-        
     def obj_get(self, bundle, **kwargs):
         task = AsyncResult(kwargs['pk'])
         return ValidateRedirectsCommandModel(

--- a/vaas/vaas/router/tests/test_fetcher.py
+++ b/vaas/vaas/router/tests/test_fetcher.py
@@ -15,13 +15,17 @@ class TestFetcher(TestCase):
                            json={'director': 'first', 'route': 1},
                            status_code=203)
             expected_response = {'status_code': 203, 'director': 'first', 'route': 1}
-            self.assertEqual(expected_response, Fetcher()._fetch('http://test.com/first-route'))
+            self.assertEqual(
+                expected_response, Fetcher()._fetch('http://test.com/first-route', Fetcher.ROUTE_VALIDATION)
+            )
 
     def test_should_return_validation_data_on_connection_exception(self):
         with requests_mock.Mocker() as m:
             m.register_uri('GET', 'http://test.com/first-route', exc=requests.exceptions.ConnectTimeout)
             expected_response = {'status_code': 0}
-            self.assertEqual(expected_response, Fetcher()._fetch('http://test.com/first-route'))
+            self.assertEqual(
+                expected_response, Fetcher()._fetch('http://test.com/first-route', Fetcher.ROUTE_VALIDATION)
+            )
 
     def test_should_check_positive_urls(self):
         route = Route(pk=1)

--- a/vaas/vaas/vcl/renderer.py
+++ b/vaas/vaas/vcl/renderer.py
@@ -185,7 +185,6 @@ class VclTagBuilder(object):
                     redirects[redirect.src_domain.domain] = [redirect]
         return redirects
 
-
     @collect_processing
     def prepare_route(self, varnish, cluster_directors):
         routes = []
@@ -314,7 +313,8 @@ class VclTagBuilder(object):
         return result
 
     def get_tag_template_name(self, tag_name):
-        return tag_name.replace('_{DIRECTOR}', '').replace('_{DC}', '').replace('_{PROBE}', '').replace('_{ROUTE}', '').replace('_{REDIRECT}', '')
+        return tag_name.replace('_{DIRECTOR}', '').replace('_{DC}', '').replace('_{PROBE}', '')\
+            .replace('_{ROUTE}', '').replace('_{REDIRECT}', '')
 
     def decorate_single_tag(self, tag_name):
         vcl_tag = VclTagExpander(tag_name, self.get_tag_template_name(tag_name), self.input, can_overwrite=True)
@@ -362,7 +362,7 @@ class VclRendererInput(object):
         ))
         self.routes.sort(key=lambda route: "{:03d}-{}".format(route.priority, route.director.name))
         self.redirects = list(Redirect.objects.all())
-        ## TODO: add sort by priority
+        # TODO: add sort by priority
         self.dcs = list(Dc.objects.all())
         self.template_blocks = list(VclTemplateBlock.objects.all().prefetch_related('template'))
         self.vcl_variables = list(VclVariable.objects.all())

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/FLEXIBLE_ROUTER.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/FLEXIBLE_ROUTER.tvcl
@@ -18,7 +18,7 @@
 
 # Flexible REDIRECT
 {% for domain, redirect_list in redirects.items() %}
-    if (req.http.host ~ "{{ domain }}") {
+    if (req.http.host == "{{ domain }}") {
 {% for redirect in redirect_list %}
     {% if loop.index > 1 %}    else if {% else %}    if {% endif %}({{ redirect.condition }}) {
         <SET_REDIRECT_{{ redirect.id }}/>

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/PROPER_PROTOCOL_REDIRECT.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/PROPER_PROTOCOL_REDIRECT.tvcl
@@ -11,14 +11,14 @@ sub vcl_synth {
         synthetic ("");
         return (deliver);
     } else if (resp.status == 888) {
-        set resp.http.Location = resp.reason + req.http.host + req.http.x-destination;
+        set resp.http.Location = req.http.x-destination;
         set resp.status = std.integer(req.http.x-response-code, 301);
         synthetic ("");
         return (deliver);
     }
 }
 sub protocol_redirect {
-    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD")) {
+    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD") && req.http.X-Accept-Proto) {
         if ((req.http.X-Accept-Proto != "both") && (req.http.X-Accept-Proto != req.http.X-Forwarded-Proto)) {
             return(synth(998, req.http.X-Accept-Proto + "://"));
         }

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/SET_ACTION.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/SET_ACTION.tvcl
@@ -9,12 +9,12 @@
         set req.backend_hint = mesh_default_proxy;
     }
 {% endif %}
-    # Handler for no backend in director
-    if(req.http.x-action != "nobackend") {
-        set req.http.x-action = req.http.x-route-action;
-    }
-
     # Handler for redirect
     if(req.http.x-action == "redirect") {
         return (synth(888, req.http.X-Forwarded-Proto + "://"));
+    }
+
+    # Handler for no backend in director
+    if(req.http.x-action != "nobackend") {
+        set req.http.x-action = req.http.x-route-action;
     }

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/SET_REDIRECT.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/SET_REDIRECT.tvcl
@@ -1,3 +1,4 @@
-set req.http.x-destination = "{{ redirect.destination }}";
+set req.http.x-redirect = "{{ redirect.id }}";
+        set req.http.x-destination = "{{ redirect.destination }}";
         set req.http.x-response-code = "{{ redirect.action }}";
         set req.http.x-action = "redirect";

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/TEST_RESPONSE_SYNTH.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/TEST_RESPONSE_SYNTH.tvcl
@@ -1,9 +1,16 @@
 ## test response synth ##
 sub vcl_synth {
     if (resp.status == 601) {
-        set req.http.X-Director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
-        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.X-Director + {"" }"} );
-        set resp.http.X-Validation-Response = 1;
+        set req.http.x-director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
+        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.x-director + {"" }"} );
+        set resp.http.x-validation-response = 1;
+        set resp.http.Content-Type = "application/json";
+        set resp.status = 203;
+        return (deliver);
+    }
+    if (resp.status == 602) {
+        synthetic ( {"{ "redirect": ""} + req.http.x-redirect + {"", "location": ""} + req.http.x-destination + {"" }"} );
+        set resp.http.x-validation-response = 1;
         set resp.http.Content-Type = "application/json";
         set resp.status = 203;
         return (deliver);

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/TEST_ROUTER.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/TEST_ROUTER.tvcl
@@ -2,3 +2,6 @@
 if (req.http.{{ validation_header }} == "1") {
     return (synth(601, "Test routing response"));
 }
+if (req.http.{{ validation_header }} == "2") {
+    return (synth(602, "Test routing response"));
+}

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
@@ -101,7 +101,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "be2c5", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "b04f1", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -118,14 +118,14 @@ sub vcl_synth {
         synthetic ("");
         return (deliver);
     } else if (resp.status == 888) {
-        set resp.http.Location = resp.reason + req.http.host + req.http.x-destination;
+        set resp.http.Location = req.http.x-destination;
         set resp.status = std.integer(req.http.x-response-code, 301);
         synthetic ("");
         return (deliver);
     }
 }
 sub protocol_redirect {
-    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD")) {
+    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD") && req.http.X-Accept-Proto) {
         if ((req.http.X-Accept-Proto != "both") && (req.http.X-Accept-Proto != req.http.X-Forwarded-Proto)) {
             return(synth(998, req.http.X-Accept-Proto + "://"));
         }
@@ -154,6 +154,9 @@ sub vcl_recv {
 if (req.http.x-validation == "1") {
     return (synth(601, "Test routing response"));
 }
+if (req.http.x-validation == "2") {
+    return (synth(602, "Test routing response"));
+}
     # Call protocol redirect sub
     call protocol_redirect;
     # SET ACTION based on x-action
@@ -165,14 +168,14 @@ if (req.http.x-validation == "1") {
         # Setup default backend to use
         set req.backend_hint = mesh_default_proxy;
     }
-    # Handler for no backend in director
-    if(req.http.x-action != "nobackend") {
-        set req.http.x-action = req.http.x-route-action;
-    }
-
     # Handler for redirect
     if(req.http.x-action == "redirect") {
         return (synth(888, req.http.X-Forwarded-Proto + "://"));
+    }
+
+    # Handler for no backend in director
+    if(req.http.x-action != "nobackend") {
+        set req.http.x-action = req.http.x-route-action;
     }
     if(req.http.x-action == "nobackend") {
         return(synth(404, "<!--Director " + req.http.x-director + " has no backends or is disabled-->"));
@@ -190,9 +193,16 @@ if (req.http.x-validation == "1") {
 ## test response synth ##
 sub vcl_synth {
     if (resp.status == 601) {
-        set req.http.X-Director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
-        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.X-Director + {"" }"} );
-        set resp.http.X-Validation-Response = 1;
+        set req.http.x-director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
+        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.x-director + {"" }"} );
+        set resp.http.x-validation-response = 1;
+        set resp.http.Content-Type = "application/json";
+        set resp.status = 203;
+        return (deliver);
+    }
+    if (resp.status == 602) {
+        synthetic ( {"{ "redirect": ""} + req.http.x-redirect + {"", "location": ""} + req.http.x-destination + {"" }"} );
+        set resp.http.x-validation-response = 1;
         set resp.http.Content-Type = "application/json";
         set resp.status = 203;
         return (deliver);

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
@@ -76,7 +76,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "bcd70", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "1e666", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -93,14 +93,14 @@ sub vcl_synth {
         synthetic ("");
         return (deliver);
     } else if (resp.status == 888) {
-        set resp.http.Location = resp.reason + req.http.host + req.http.x-destination;
+        set resp.http.Location = req.http.x-destination;
         set resp.status = std.integer(req.http.x-response-code, 301);
         synthetic ("");
         return (deliver);
     }
 }
 sub protocol_redirect {
-    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD")) {
+    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD") && req.http.X-Accept-Proto) {
         if ((req.http.X-Accept-Proto != "both") && (req.http.X-Accept-Proto != req.http.X-Forwarded-Proto)) {
             return(synth(998, req.http.X-Accept-Proto + "://"));
         }
@@ -129,6 +129,9 @@ sub vcl_recv {
 if (req.http.x-validation == "1") {
     return (synth(601, "Test routing response"));
 }
+if (req.http.x-validation == "2") {
+    return (synth(602, "Test routing response"));
+}
     # Call protocol redirect sub
     call protocol_redirect;
     # SET ACTION based on x-action
@@ -140,14 +143,14 @@ if (req.http.x-validation == "1") {
         # Setup default backend to use
         set req.backend_hint = mesh_default_proxy;
     }
-    # Handler for no backend in director
-    if(req.http.x-action != "nobackend") {
-        set req.http.x-action = req.http.x-route-action;
-    }
-
     # Handler for redirect
     if(req.http.x-action == "redirect") {
         return (synth(888, req.http.X-Forwarded-Proto + "://"));
+    }
+
+    # Handler for no backend in director
+    if(req.http.x-action != "nobackend") {
+        set req.http.x-action = req.http.x-route-action;
     }
     if(req.http.x-action == "nobackend") {
         return(synth(404, "<!--Director " + req.http.x-director + " has no backends or is disabled-->"));
@@ -165,9 +168,16 @@ if (req.http.x-validation == "1") {
 ## test response synth ##
 sub vcl_synth {
     if (resp.status == 601) {
-        set req.http.X-Director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
-        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.X-Director + {"" }"} );
-        set resp.http.X-Validation-Response = 1;
+        set req.http.x-director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
+        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.x-director + {"" }"} );
+        set resp.http.x-validation-response = 1;
+        set resp.http.Content-Type = "application/json";
+        set resp.status = 203;
+        return (deliver);
+    }
+    if (resp.status == 602) {
+        synthetic ( {"{ "redirect": ""} + req.http.x-redirect + {"", "location": ""} + req.http.x-destination + {"" }"} );
+        set resp.http.x-validation-response = 1;
         set resp.http.Content-Type = "application/json";
         set resp.status = 203;
         return (deliver);

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
@@ -363,7 +363,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "dda46", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "f629b", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -380,14 +380,14 @@ sub vcl_synth {
         synthetic ("");
         return (deliver);
     } else if (resp.status == 888) {
-        set resp.http.Location = resp.reason + req.http.host + req.http.x-destination;
+        set resp.http.Location = req.http.x-destination;
         set resp.status = std.integer(req.http.x-response-code, 301);
         synthetic ("");
         return (deliver);
     }
 }
 sub protocol_redirect {
-    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD")) {
+    if (req.esi_level == 0 && (req.method == "GET" || req.method == "HEAD") && req.http.X-Accept-Proto) {
         if ((req.http.X-Accept-Proto != "both") && (req.http.X-Accept-Proto != req.http.X-Forwarded-Proto)) {
             return(synth(998, req.http.X-Accept-Proto + "://"));
         }
@@ -435,8 +435,9 @@ sub vcl_recv {
     unset req.http.x-canary-random;
 
 # Flexible REDIRECT
-    if (req.http.host ~ "example.com") {
+    if (req.http.host == "example.com") {
     if (req.method == "GET" && req.url ~ "/source") {
+        set req.http.x-redirect = "1";
         set req.http.x-destination = "/destination";
         set req.http.x-response-code = "301";
         set req.http.x-action = "redirect";
@@ -447,17 +448,20 @@ sub vcl_recv {
 if (req.http.x-validation == "1") {
     return (synth(601, "Test routing response"));
 }
+if (req.http.x-validation == "2") {
+    return (synth(602, "Test routing response"));
+}
     # Call protocol redirect sub
     call protocol_redirect;
     # SET ACTION based on x-action
-    # Handler for no backend in director
-    if(req.http.x-action != "nobackend") {
-        set req.http.x-action = req.http.x-route-action;
-    }
-
     # Handler for redirect
     if(req.http.x-action == "redirect") {
         return (synth(888, req.http.X-Forwarded-Proto + "://"));
+    }
+
+    # Handler for no backend in director
+    if(req.http.x-action != "nobackend") {
+        set req.http.x-action = req.http.x-route-action;
     }
     if(req.http.x-action == "nobackend") {
         return(synth(404, "<!--Director " + req.http.x-director + " has no backends or is disabled-->"));
@@ -475,9 +479,16 @@ if (req.http.x-validation == "1") {
 ## test response synth ##
 sub vcl_synth {
     if (resp.status == 601) {
-        set req.http.X-Director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
-        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.X-Director + {"" }"} );
-        set resp.http.X-Validation-Response = 1;
+        set req.http.x-director = regsuball(req.http.X-VaaS-Director, ".*/", "\1");
+        synthetic ( {"{ "route": ""} + req.http.X-Route + {"", "director": ""} + req.http.x-director + {"" }"} );
+        set resp.http.x-validation-response = 1;
+        set resp.http.Content-Type = "application/json";
+        set resp.status = 203;
+        return (deliver);
+    }
+    if (resp.status == 602) {
+        synthetic ( {"{ "redirect": ""} + req.http.x-redirect + {"", "location": ""} + req.http.x-destination + {"" }"} );
+        set resp.http.x-validation-response = 1;
         set resp.http.Content-Type = "application/json";
         set resp.status = 203;
         return (deliver);

--- a/vaas/vaas/vcl/tests/test_renderer.py
+++ b/vaas/vaas/vcl/tests/test_renderer.py
@@ -109,13 +109,18 @@ class VclTagBuilderTest(TestCase):
         settings.SIGNALS = 'off'
         self.dc2 = DcFactory.create(name='Tokyo', symbol="dc2")
         self.dc1 = DcFactory.create(name="Bilbao", symbol="dc1")
-        cluster1 = LogicalClusterFactory.create(id=1, name='cluster1_siteA_test', labels_list='["example.com", "placeholder:dev1"]')
+        cluster1 = LogicalClusterFactory.create(
+            id=1, name='cluster1_siteA_test', labels_list='["example.com", "placeholder:dev1"]'
+        )
         cluster2 = LogicalClusterFactory.create(id=2, name='cluster2_siteB_test', labels_list='["env:prod"]')
         cluster3_with_mesh_service = LogicalClusterFactory.create(
             id=3, name='cluster3_siteB_test_with_mesh_service', service_mesh_routing=True, labels_list='["cluster3"]'
         )
         cluster4_with_mesh_and_standard_service = LogicalClusterFactory.create(
-            id=4, name='cluster4_siteB_test_with_mesh_and_standard_service', service_mesh_routing=True, labels_list='["cluster4"]'
+            id=4,
+            name='cluster4_siteB_test_with_mesh_and_standard_service',
+            service_mesh_routing=True,
+            labels_list='["cluster4"]'
         )
         self.domainapping = DomainMapping.objects.create(domain='example.com', mapping='example.base.com', type=301)
         self.domainapping.clusters.add(cluster2)


### PR DESCRIPTION
What has been done:
- extended TEST_ROUTER with logic providing meta-information about the chosen redirect
- fixed creating objects representing validation results (casting to int)
- fixed redirect conditions operator (equal instead of match)
- fixed redirect location content (should not be composed with x-forwarded-proto and current domain)
- fixed proper_redirect_protocol function (should not redirect to broken URLs if X-Accept-Proto is not set)
- fixed linter errors