### PR TITLE
Return HTTP 503 from /vaas_status if file /etc/return_503 exists

### DIFF
--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -246,6 +246,8 @@ CLUSTER_IN_SYNC_ENABLED = env.bool('CLUSTER_IN_SYNC_ENABLED', default=False)
 MESH_X_ORIGINAL_HOST = env.str('MESH_X_ORIGINAL_HOST', default='x-original-host')
 SERVICE_TAG_HEADER = env.str('SERVICE_TAG_HEADER', default='x-service-tag')
 
+# If file exists in specified path /vaas_status endpoint will return HTTP 503 code
+VAAS_STATUS_CODE_503_TRIGGER_FILE = env.str('VAAS_STATUS_CODE_503_TRIGGER_FILE', default='/etc/vaas_status_503')
 
 # CELERY
 def generate_redis_url(hostname: str, port: int, db_number: int, password: Optional[str] = None) -> str:

--- a/vaas/vaas/vcl/renderer.py
+++ b/vaas/vaas/vcl/renderer.py
@@ -291,6 +291,7 @@ class VclTagBuilder(object):
         if tag_name == 'VAAS_STATUS':
             vcl_tag.parameters['server'] = self.varnish
             vcl_tag.parameters['allow_metrics_header'] = settings.ALLOW_METRICS_HEADER
+            vcl_tag.parameters['vaas_status_code_503_trigger_file'] = settings.VAAS_STATUS_CODE_503_TRIGGER_FILE
         elif tag_name in ('RECV'):
             vcl_tag.parameters['mesh_routing'] = self.placeholders['mesh_routing']
         elif tag_name == 'SET_ACTION':

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/VAAS_STATUS.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/VAAS_STATUS.tvcl
@@ -15,6 +15,9 @@ sub vcl_synth {
         {% else %}
             set resp.status = 503;
         {% endif %}
+        if (std.file_exists("/etc/return_503")) {
+            set resp.status = 503;
+        }
         synthetic("");
     }
     if (resp.status == 989) {

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/VAAS_STATUS.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/VAAS_STATUS.tvcl
@@ -15,7 +15,7 @@ sub vcl_synth {
         {% else %}
             set resp.status = 503;
         {% endif %}
-        if (std.file_exists("/etc/return_503")) {
+        if (std.file_exists("{{ vaas_status_code_503_trigger_file }}")) {
             set resp.status = 503;
         }
         synthetic("");

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
@@ -331,7 +331,7 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
-        if (std.file_exists("/etc/return_503")) {
+        if (std.file_exists("/etc/vaas_status_503")) {
             set resp.status = 503;
         }
         synthetic("");
@@ -339,7 +339,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "41b31", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "24eec", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
@@ -331,12 +331,15 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
+        if (std.file_exists("/etc/return_503")) {
+            set resp.status = 503;
+        }
         synthetic("");
     }
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "1059a", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "41b31", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
@@ -96,7 +96,7 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
-        if (std.file_exists("/etc/return_503")) {
+        if (std.file_exists("/etc/vaas_status_503")) {
             set resp.status = 503;
         }
         synthetic("");
@@ -104,7 +104,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "996d0", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "99708", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh-and-standard-service.vcl
@@ -96,12 +96,15 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
+        if (std.file_exists("/etc/return_503")) {
+            set resp.status = 503;
+        }
         synthetic("");
     }
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "5feca", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "996d0", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
@@ -71,12 +71,15 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
+        if (std.file_exists("/etc/return_503")) {
+            set resp.status = 503;
+        }
         synthetic("");
     }
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "51963", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "d8fa0", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-with-mesh_service.vcl
@@ -71,7 +71,7 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
-        if (std.file_exists("/etc/return_503")) {
+        if (std.file_exists("/etc/vaas_status_503")) {
             set resp.status = 503;
         }
         synthetic("");
@@ -79,7 +79,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "d8fa0", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "981e1", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
@@ -358,7 +358,7 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
-        if (std.file_exists("/etc/return_503")) {
+        if (std.file_exists("/etc/vaas_status_503")) {
             set resp.status = 503;
         }
         synthetic("");
@@ -366,7 +366,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "8f857", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "f33a6", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
@@ -358,12 +358,15 @@ sub vcl_recv {
 sub vcl_synth {
     if (resp.status == 999) {
             set resp.status = 503;
+        if (std.file_exists("/etc/return_503")) {
+            set resp.status = 503;
+        }
         synthetic("");
     }
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "d25f7", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "8f857", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }


### PR DESCRIPTION
What has been done:
- Return HTTP 503 from /vaas_status if file defined in settings (`VAAS_STATUS_CODE_503_TRIGGER_FILE` variable) exists - needed for gracefull shutdown od k8s.