### PR TITLE
Render VCL with redirect and regsub

### DIFF
--- a/vaas/vaas/adminext/templates/forms/rewrite_groups.html
+++ b/vaas/vaas/adminext/templates/forms/rewrite_groups.html
@@ -1,5 +1,5 @@
 {% spaceless %}
-<div class="input-group" id="input-group">
+<div class="input-group"  {% include "django/forms/widgets/attrs.html" %}">
     {% for widget in widget.subwidgets %}
     {% if forloop.first %}
     <span class="input-group-addon">
@@ -26,9 +26,9 @@
         };
 
         function updateTarget(oldState, newState) {
-            $("#input-group").removeClass(oldState)
+            $("#id_rewrite_groups").removeClass(oldState)
             if (newState != Validation.Unknown) {
-                $("#input-group").addClass(newState)
+                $("#id_rewrite_groups").addClass(newState)
             }
         }
 
@@ -59,6 +59,9 @@
         }
 
         $(document).ready(function () {
+            if($("#id_rewrite_groups_1").val()) {
+                setRegexCompilationState(Validation.Success);
+            }
             $('#id_rewrite_groups_0').change(function () {
                 if ($(this).is(":checked")) {
                     $("#id_rewrite_groups_1").prop('disabled', false);

--- a/vaas/vaas/vcl/templates/vcl_blocks/4.0/SET_REDIRECT.tvcl
+++ b/vaas/vaas/vcl/templates/vcl_blocks/4.0/SET_REDIRECT.tvcl
@@ -1,4 +1,8 @@
 set req.http.x-redirect = "{{ redirect.id }}";
+        {% if redirect.rewrite_groups %}
+        set req.http.x-destination = regsub(req.url, "{{ redirect.rewrite_groups }}", "{{ redirect.destination }}");
+        {% else %}
         set req.http.x-destination = "{{ redirect.destination }}";
+        {% endif %}
         set req.http.x-response-code = "{{ redirect.action }}";
         set req.http.x-action = "redirect";


### PR DESCRIPTION
- Fix frontend validation status when form is loaded
    > I decided to make it on frontend site, I don't want split logic between python & JS code.
- Fix id conflict in html for `input-group`
- Create redirect location with `regsub` when `rewrite_groups` is present in `Redirect` model

Testing:
![Zrzut ekranu 2022-12-20 o 12 49 45](https://user-images.githubusercontent.com/9092412/208660243-4a7066d1-39ff-466b-9449-4098fe04fc0c.png)

Result:
```
curl -X GET -I 192.168.199.6:6081/wakacje/123/dsdsd
HTTP/1.1 301 Moved Permanently
Date: Tue, 20 Dec 2022 10:07:02 GMT
Server: Varnish
X-Varnish: 98312
Location: /nowe-wakacje/123
Content-Length: 0
Connection: keep-alive
```