### PR TITLE
ability of hiding option cluster_in_sync in the GUI

### DIFF
--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -243,6 +243,7 @@ STATSD_PREFIX = env.str('STATSD_PREFIX', default='example.statsd.path')
 ALLOW_METRICS_HEADER = env.bool('ALLOW_METRICS_HEADER', default='x-allow-metric-header')
 
 CLUSTER_IN_SYNC_ENABLED = env.bool('CLUSTER_IN_SYNC_ENABLED', default=False)
+CLUSTER_IN_SYNC_HIDDEN = env.bool('ROUTE_CLUSTER_IN_SYNC_ENABLED', default=False)
 MESH_X_ORIGINAL_HOST = env.str('MESH_X_ORIGINAL_HOST', default='x-original-host')
 SERVICE_TAG_HEADER = env.str('SERVICE_TAG_HEADER', default='x-service-tag')
 


### PR DESCRIPTION
What has been done:
- adding new configuration variable `CLUSTER_IN_SYNC_HIDDEN` that controls if `cluster_in_sync` option is available in route form
- if the mentioned option is not available then the default value is forcibly set during editing route