### PR TITLE
move ordering of route/redirect validation report to common js file

### DIFF
--- a/vaas/vaas/manager/templates/router/admin_app_redirect_description.html
+++ b/vaas/vaas/manager/templates/router/admin_app_redirect_description.html
@@ -1,83 +1,5 @@
-<style>
-  .loader {
-    border: 5px solid #f3f3f3;
-    border-radius: 50%;
-    border-top: 5px solid #555;
-    width: 50px;
-    height: 50px;
-    -webkit-animation: spin 1s linear infinite;
-    animation: spin 1s linear infinite;
-  }
-
-  @-webkit-keyframes spin {
-    0% {
-      -webkit-transform: rotate(0deg);
-    }
-
-    100% {
-      -webkit-transform: rotate(360deg);
-    }
-  }
-
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-</style>
 <script>
-  const noDataPlaceholder = { name: 'no data', id: 'no data' };
-  function redirectsValidateCommand(url) {
-    return $.ajax({
-      type: 'PUT',
-      url: url,
-      data: '{}',
-      dataType: 'json',
-      contentType: "application/json; charset=utf-8",
-      error: handleErrorResponse,
-      success: handleRedirectsValidateResponse,
-      beforeSend: setCRSFToken,
-      complete: function () { if (isResultStillAwaited(url)) { setTimeout(function () { poolRedirectsValidateResult(url) }, 500) } },
-    });
-  }
-
-  function poolRedirectsValidateResult(url) {
-    $.ajax({
-      url: url,
-      dataType: 'json',
-      error: handleErrorResponse,
-      success: handleRedirectsValidateResponse,
-      complete: function () { if (isResultStillAwaited(url)) { setTimeout(function () { poolRedirectsValidateResult(url) }, 500) } },
-      timeout: 5000
-    });
-  }
-
-  function handleRedirectsValidateResponse(data, textStatus, request) {
-    const status = data.status
-    if (checkCommandStatus('done')) return;
-    if (status === 'FAILURE') {
-      setCommandStatus('done');
-      showError("Can't generate report. Task failed. Refresh page and try again")
-      $('#spinner').hide()
-    }
-    else if (status === 'SUCCESS') {
-      setCommandStatus('done');
-      $('#results').append(createTestResult(data.output.validation_results))
-      $('#pass-count').text(countResult('PASS', data.output.validation_results));
-      $('#failed-count').text(countResult('FAIL', data.output.validation_results));
-      $('#command-result').addClass(`label-${statusToClass(data.output.validation_status)}`).text(data.output.validation_status);
-      $('#spinner').hide()
-    }
-    $('#command-status').removeClass();
-    $('#command-status').addClass(`label label-${statusToClass(status)}`).text(status);
-  }
-
   function createTestResult(records) {
-    var html = '';
     records.sort(function(x, y) {
       if (x.error_message && !y.error_message) {
         return -1;
@@ -90,127 +12,59 @@
       }
       return 1;
     });
+    let html = '';
     records.forEach(function (record) {
       var errorMsg = ''
-      if (!record.current.redirect) record.current.redirect = noDataPlaceholder
-      if (record.error_message) errorMsg = `<div class="alert alert-danger" role="alert">${record.error_message}</div>`
-      html += `<div class="panel panel-${statusToClass(record.result)}">
-          <div class="panel-heading">
-            <h3 class="panel-title">${record.url}</h3>
-          </div>
-          <div class="panel-body">
-            ${errorMsg}
-            <div class="row">
-              <div class="col-md-6">
-                <div class="panel panel-default">
-                  <div class="panel-body">
-                    <h5><strong>Location:</strong> <code>${record.current.location}</code></h5>
-                    <h6 class="text-muted">redirect.contition: ${record.current.redirect.name}</h6>
-                    <h6 class="text-muted">redirect.id: ${record.current.redirect.id}</h6>
-                  </div>
-                  <div class="panel-footer">
-                    Current
-                  </div>
-                </div>
-              </div>
-                <div class="col-md-6">
-                  <div class="panel panel-default">
-                    <div class="panel-body">
-                      <h5><strong>Location:</strong> <code>${record.expected.location}</code></h5>
-                      <h6 class="text-muted">redirect.contition: ${record.expected.redirect.name}</h6>
-                      <h6 class="text-muted">redirect.id: ${record.expected.redirect.id}</h6>
-                    </div>
-                    <div class="panel-footer">
-                      Excpeted
-                    </div>
-                  </div>
-                </div>
-            </div>
-          </div>
-        </div>`
+      if (!record.current.redirect) record.current.redirect = { name: 'no data', id: 'no data' };
+      if (record.error_message) record.error_message = `<div class="alert alert-danger" role="alert">${record.error_message}</div>`
+      html += eval('`' + $("#test-case").html() + '`');
     });
     return html
   }
 
-  function countResult(resultString, records) {
-    var counter = 0;
-    records.forEach(function (record) {
-      if (record.result === resultString) {
-        counter += 1
-      }
-    })
-    return counter;
-  }
-
-  function handleErrorResponse(request, textStatus, errorThrown) {
-    setCommandStatus('done');
-    console.error(textStatus, errorThrown)
-    $('#command-details').append(`<div id="error-message" class="alert alert-danger" role="alert">${request.responseText || errorThrown}</div>`)
-    $('#command-result').addClass(`label-${statusToClass('FAIL')}`).text(validationStatus('Error'));
-    $('#spinner').hide();
-  }
-
-  function showError(message) {
-    $('#error-message').remove()
-    $('#command-details').append(`<div id="error-message" class="alert alert-danger" role="alert">${message}</div>`)
-  }
-
-  function isPollingFinished(commandId, status) {
-    return $('#command-id').text() != commandId || checkCommandStatus('done')
-  }
-
-  function isResultStillAwaited(commandURL) {
-    var parts = commandURL.split('/')
-    return !isPollingFinished(parts[parts.length - 2], 'done');
-  }
-
-  function setCommandStatus(status) {
-    $('#command-id').data('status', status)
-  }
-
-  function checkCommandStatus(status) {
-    return $('#command-id').data('status') == status
-  }
-
-  function statusToClass(status) {
-    switch (status) {
-      case 'PENDING':
-        return 'info';
-      case 'PASS':
-      case 'SUCCESS':
-        return 'success'
-      case 'FAIL':
-      case 'FAILURE':
-        return 'danger'
-      default:
-        return 'default'
-    }
-  }
-
-  function clearModal(commandId) {
-    $('#spinner').show();
-    $('#results').text("");
-    $('#pass-count').text(0);
-    $('#failed-count').text(0);
-    $('#error-message').remove();
-    $('#command-status').removeClass();
-    $('#command-status').addClass(`label label-default`).text("unknown");
-    $('#command-result').removeClass();
-    $('#command-result').addClass(`label label-default`).text("UNKNOWN");
-    $('#command-id').text(commandId);
-    $('#command-id').data("status", "started");
-  }
-
   $(document).ready(function () {
-    var testResultModalEl = $('#testResultModal');
-    testResultModalEl.on('show.bs.modal', function (event) {
-      var commandId = Date.now().toString(36) + Math.random().toString(36).substring(2);
-      clearModal(commandId)
-      redirectsValidateCommand('/api/v0.1/redirect/validate-command/' + commandId + '/');
-    });
+    initReport('/api/v0.1/redirect/validate-command/', createTestResult);
   })
 
 </script>
+
+<template id="test-case">
+  <div class="panel panel-${statusToClass(record.result)}">
+    <div class="panel-heading">
+      <h3 class="panel-title">${record.url}</h3>
+    </div>
+    <div class="panel-body">
+      ${record.error_message}
+      <div class="row">
+        <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <h5><strong>Location:</strong> <code>${record.current.location}</code></h5>
+              <h6 class="text-muted">redirect.condition: ${record.current.redirect.name}</h6>
+              <h6 class="text-muted">redirect.id: ${record.current.redirect.id}</h6>
+            </div>
+            <div class="panel-footer">
+              Current
+            </div>
+          </div>
+        </div>
+          <div class="col-md-6">
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <h5><strong>Location:</strong> <code>${record.expected.location}</code></h5>
+                <h6 class="text-muted">redirect.condition: ${record.expected.redirect.name}</h6>
+                <h6 class="text-muted">redirect.id: ${record.expected.redirect.id}</h6>
+              </div>
+              <div class="panel-footer">
+                Expected
+              </div>
+            </div>
+          </div>
+      </div>
+    </div>
+  </div>
+</template>
+
 <div class='pull-right'>
   <button id="test" type="button" class="btn btn-info" data-toggle="modal" data-target="#testResultModal">
     Run redirects test

--- a/vaas/vaas/manager/templates/router/admin_app_route_description.html
+++ b/vaas/vaas/manager/templates/router/admin_app_route_description.html
@@ -1,218 +1,73 @@
 {% if route_tests_enabled %}
-<style>
-  .loader {
-    border: 5px solid #f3f3f3;
-    border-radius: 50%;
-    border-top: 5px solid #555;
-    width: 50px;
-    height: 50px;
-    -webkit-animation: spin 1s linear infinite;
-    animation: spin 1s linear infinite;
-  }
-
-  @-webkit-keyframes spin {
-    0% {
-      -webkit-transform: rotate(0deg);
-    }
-
-    100% {
-      -webkit-transform: rotate(360deg);
-    }
-  }
-
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-</style>
 <script>
-  const noDataPlaceholder = { name: 'no data', id: 'no data' };
-  function routesValidateCommand(url) {
-    return $.ajax({
-      type: 'PUT',
-      url: url,
-      data: '{}',
-      dataType: 'json',
-      contentType: "application/json; charset=utf-8",
-      error: handleErrorResponse,
-      success: handleRoutesValidateResponse,
-      beforeSend: setCRSFToken,
-      complete: function () { if (isResultStillAwaited(url)) { setTimeout(function () { poolRoutesValidateResult(url) }, 500) } },
-    });
-  }
 
-  function poolRoutesValidateResult(url) {
-    $.ajax({
-      url: url,
-      dataType: 'json',
-      error: handleErrorResponse,
-      success: handleRoutesValidateResponse,
-      complete: function () { if (isResultStillAwaited(url)) { setTimeout(function () { poolRoutesValidateResult(url) }, 500) } },
-      timeout: 5000
-    });
-  }
+const noDataPlaceholder = { name: 'no data', id: 'no data' };
 
-  function handleRoutesValidateResponse(data, textStatus, request) {
-    const status = data.status
-    if (checkCommandStatus('done')) return;
-    if (status === 'FAILURE') {
-      setCommandStatus('done');
-      showError("Can't generate report. Task failed. Refresh page and try again")
-      $('#spinner').hide()
+function createTestResult(records) {
+  records.sort(function(x, y) {
+    if (x.error_message && !y.error_message) {
+      return -1;
     }
-    else if (status === 'SUCCESS') {
-      setCommandStatus('done');
-      $('#results').append(createTestResult(data.output.validation_results))
-      $('#pass-count').text(countResult('PASS', data.output.validation_results));
-      $('#failed-count').text(countResult('FAIL', data.output.validation_results));
-      $('#command-result').addClass(`label-${statusToClass(data.output.validation_status)}`).text(data.output.validation_status);
-      $('#spinner').hide()
-    }
-    $('#command-status').removeClass();
-    $('#command-status').addClass(`label label-${statusToClass(status)}`).text(status);
-  }
-
-  function createTestResult(records) {
-    var html = '';
-    records.sort(function(x, y) {
-      if (x.error_message && !y.error_message) {
-        return -1;
-      }
-      if (!x.error_message && y.error_message) {
-        return 1;
-      }
-      if (x.expected.route.id < y.expected.route.id) {
-        return -1;
-      }
+    if (!x.error_message && y.error_message) {
       return 1;
-    });
-    records.forEach(function (record) {
-      var errorMsg = ''
-      if (!record.current.route) record.current.route = noDataPlaceholder
-      if (!record.current.director) record.current.director = noDataPlaceholder
-      if (record.error_message) errorMsg = `<div class="alert alert-danger" role="alert">${record.error_message}</div>`
-      html += `<div class="panel panel-${statusToClass(record.result)}">
-          <div class="panel-heading">
-            <h3 class="panel-title">${record.url}</h3>
-          </div>
-          <div class="panel-body">
-            ${errorMsg}
-            <div class="row">
-              <div class="col-md-6">
-                <div class="panel panel-default">
-                  <div class="panel-body">
-                    <h5><strong>Director: </strong>${record.expected.director.name}</h5>
-                    <h5><strong>Route:</strong> <code>${record.expected.route.name}</code></h5>
-                    <h6 class="text-muted">director.id: ${record.expected.director.id}</h6>
-                    <h6 class="text-muted">route.id: ${record.expected.route.id}</h6>
-                  </div>
-                  <div class="panel-footer">
-                    Expected
-                  </div>
-                </div>
+    }
+    if (x.expected.route.id < y.expected.route.id) {
+      return -1;
+    }
+    return 1;
+  });
+  let html = "";
+  records.forEach(function (record) {
+    if (!record.current.route) record.current.route = noDataPlaceholder;
+    if (!record.current.director) record.current.director = noDataPlaceholder;
+    if (record.error_message) record.error_message = `<div class="alert alert-danger" role="alert">${record.error_message}</div>`;
+    html += eval('`' + $("#test-case").html() + '`');
+  });
+  return html
+}
+
+$(document).ready(function () {
+  initReport('/api/v0.1/route/validate-command/', createTestResult);
+})
+</script>
+
+<template id="test-case">
+  <div class="panel panel-${statusToClass(record.result)}">
+      <div class="panel-heading">
+        <h3 class="panel-title">${record.url}</h3>
+      </div>
+      <div class="panel-body">
+        ${record.error_message}
+        <div class="row">
+          <div class="col-md-6">
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <h5><strong>Director: </strong>${record.expected.director.name}</h5>
+                <h5><strong>Route:</strong> <code>${record.expected.route.name}</code></h5>
+                <h6 class="text-muted">director.id: ${record.expected.director.id}</h6>
+                <h6 class="text-muted">route.id: ${record.expected.route.id}</h6>
               </div>
-                <div class="col-md-6">
-                  <div class="panel panel-default">
-                    <div class="panel-body">
-                      <h5>Director: ${record.current.director.name}</h5>
-                      <h5>Route: <code>${record.current.route.name}</code></h5>
-                      <h6 class="text-muted">director.id: ${record.current.director.id}</h6>
-                      <h6 class="text-muted">route.id: ${record.current.route.id}</h6>
-                    </div>
-                    <div class="panel-footer">Current</div>
-                  </div>
-                </div>
+              <div class="panel-footer">
+                Expected
+              </div>
             </div>
           </div>
-        </div>`
-    });
-    return html
-  }
+            <div class="col-md-6">
+              <div class="panel panel-default">
+                <div class="panel-body">
+                  <h5>Director: ${record.current.director.name}</h5>
+                  <h5>Route: <code>${record.current.route.name}</code></h5>
+                  <h6 class="text-muted">director.id: ${record.current.director.id}</h6>
+                  <h6 class="text-muted">route.id: ${record.current.route.id}</h6>
+                </div>
+                <div class="panel-footer">Current</div>
+              </div>
+            </div>
+        </div>
+      </div>
+    </div>
+</template>
 
-  function countResult(resultString, records) {
-    var counter = 0;
-    records.forEach(function (record) {
-      if (record.result === resultString) {
-        counter += 1
-      }
-    })
-    return counter;
-  }
-
-  function handleErrorResponse(request, textStatus, errorThrown) {
-    setCommandStatus('done');
-    console.error(textStatus, errorThrown)
-    $('#command-details').append(`<div id="error-message" class="alert alert-danger" role="alert">${request.responseText || errorThrown}</div>`)
-    $('#command-result').addClass(`label-${statusToClass('FAIL')}`).text(validationStatus('Error'));
-    $('#spinner').hide();
-  }
-
-  function showError(message) {
-    $('#error-message').remove()
-    $('#command-details').append(`<div id="error-message" class="alert alert-danger" role="alert">${message}</div>`)
-  }
-
-  function isPollingFinished(commandId, status) {
-    return $('#command-id').text() != commandId || checkCommandStatus('done')
-  }
-
-  function isResultStillAwaited(commandURL) {
-    var parts = commandURL.split('/')
-    return !isPollingFinished(parts[parts.length - 2], 'done');
-  }
-
-  function setCommandStatus(status) {
-    $('#command-id').data('status', status)
-  }
-
-  function checkCommandStatus(status) {
-    return $('#command-id').data('status') == status
-  }
-
-  function statusToClass(status) {
-    switch (status) {
-      case 'PENDING':
-        return 'info';
-      case 'PASS':
-      case 'SUCCESS':
-        return 'success'
-      case 'FAIL':
-      case 'FAILURE':
-        return 'danger'
-      default:
-        return 'default'
-    }
-  }
-
-  function clearModal(commandId) {
-    $('#spinner').show();
-    $('#results').text("");
-    $('#pass-count').text(0);
-    $('#failed-count').text(0);
-    $('#error-message').remove();
-    $('#command-status').removeClass();
-    $('#command-status').addClass(`label label-default`).text("unknown");
-    $('#command-result').removeClass();
-    $('#command-result').addClass(`label label-default`).text("UNKNOWN");
-    $('#command-id').text(commandId);
-    $('#command-id').data("status", "started");
-  }
-
-  $(document).ready(function () {
-    var testResultModalEl = $('#testResultModal');
-    testResultModalEl.on('show.bs.modal', function (event) {
-      var commandId = Date.now().toString(36) + Math.random().toString(36).substring(2);
-      clearModal(commandId)
-      routesValidateCommand('/api/v0.1/route/validate-command/' + commandId + '/');
-    });
-  })
-
-</script>
 <div class='pull-right'>
   <button id="test" type="button" class="btn btn-info" data-toggle="modal" data-target="#testResultModal">
     Run routes test

--- a/vaas/vaas/router/admin.py
+++ b/vaas/vaas/router/admin.py
@@ -17,6 +17,10 @@ class RedirectAdmin(AuditableModelAdmin):
     search_fields = ['condition', 'src_domain__domain', 'destination']
     list_display = ['condition', 'src_domain', 'destination', 'action', 'priority', 'preserve_query_params']
 
+    class Media:
+        js = ('utils/js/labels.js', 'js/test-report.js', )
+        css = {'all': ('css/test-report.css', )}
+
 
 class RouteAdmin(AuditableModelAdmin):
     form = RouteModelForm
@@ -38,7 +42,8 @@ class RouteAdmin(AuditableModelAdmin):
         return super().changelist_view(request, extra_context=ctx)
 
     class Media:
-        js = ('js/clusters-sync.js', 'utils/js/labels.js')
+        js = ('js/clusters-sync.js', 'js/test-report.js', 'utils/js/labels.js')
+        css = {'all': ('css/test-report.css', )}
 
 
 admin.site.register(Route, RouteAdmin)

--- a/vaas/vaas/router/static/css/test-report.css
+++ b/vaas/vaas/router/static/css/test-report.css
@@ -1,0 +1,27 @@
+.loader {
+    border: 5px solid #f3f3f3;
+    border-radius: 50%;
+    border-top: 5px solid #555;
+    width: 50px;
+    height: 50px;
+    -webkit-animation: spin 1s linear infinite;
+    animation: spin 1s linear infinite;
+}
+
+@-webkit-keyframes spin {
+0% {
+  -webkit-transform: rotate(0deg);
+}
+100% {
+  -webkit-transform: rotate(360deg);
+}
+}
+
+@keyframes spin {
+0% {
+  transform: rotate(0deg);
+}
+100% {
+  transform: rotate(360deg);
+}
+}

--- a/vaas/vaas/router/static/js/test-report.js
+++ b/vaas/vaas/router/static/js/test-report.js
@@ -1,0 +1,112 @@
+class ReportGateway {
+    constructor(url, renderResults) {
+      this.commandId = Date.now().toString(36) + Math.random().toString(36).substring(2);
+      this.url = url + this.commandId + "/";
+      this.renderResults = renderResults
+
+      $('#spinner').show();
+      $('#results').text("");
+      $('#pass-count').text(0);
+      $('#failed-count').text(0);
+      $('#error-message').remove();
+      $('#command-status').removeClass();
+      $('#command-status').addClass(`label label-default`).text("unknown");
+      $('#command-result').removeClass();
+      $('#command-result').addClass(`label label-default`).text("UNKNOWN");
+      $('#command-id').text(this.commandId);
+      $('#command-id').data("status", "started");
+    }
+
+    order() {
+      return $.ajax({
+        type: 'PUT',
+        url: this.url,
+        data: '{}',
+        dataType: 'json',
+        contentType: "application/json; charset=utf-8",
+        error: (request, textStatus, errorThrown) => {this.handleErrorResponse(request, textStatus, errorThrown)},
+        success: (data, textStatus, request) => {this.handleSuccessResponse(data, textStatus, request)},
+        beforeSend: setCRSFToken,
+        complete: () => {this.complete()},
+      });
+    }
+
+    pollResult() {
+      $.ajax({
+        url: this.url,
+        dataType: 'json',
+        error: (request, textStatus, errorThrown) => {this.handleErrorResponse(request, textStatus, errorThrown)},
+        success: (data, textStatus, request) => {this.handleSuccessResponse(data, textStatus, request)},
+        complete: () => {this.complete()},
+        timeout: 5000
+      });
+    }
+
+    complete() {
+        if (this.isResultStillAwaited()) {
+            setTimeout(() => {this.pollResult()}, 500)
+        }
+    }
+
+    handleSuccessResponse(data, textStatus, request) {
+      const status = data.status
+      if (this.checkCommandStatus('done')) return;
+      if (status === 'FAILURE') {
+        this.setCommandStatus('done');
+        this.showError("Can't generate report. Task failed. Refresh page and try again")
+      }
+      else if (status === 'SUCCESS') {
+        this.setCommandStatus('done');
+        $('#results').append(this.renderResults(data.output.validation_results));
+        $('#pass-count').text(this.countResult('PASS', data.output.validation_results));
+        $('#failed-count').text(this.countResult('FAIL', data.output.validation_results));
+        $('#command-result').addClass(`label-${statusToClass(data.output.validation_status)}`).text(data.output.validation_status);
+      }
+      $('#spinner').hide();
+      $('#command-status').removeClass();
+      $('#command-status').addClass(`label label-${statusToClass(status)}`).text(status);
+    }
+
+    countResult(resultString, records) {
+      var counter = 0;
+      records.forEach(function (record) {
+        if (record.result === resultString) {
+          counter += 1
+        }
+      })
+      return counter;
+    }
+
+    handleErrorResponse(request, textStatus, errorThrown) {
+      this.setCommandStatus('done');
+      console.error(textStatus, errorThrown);
+      $('#command-details').append(`<div id="error-message" class="alert alert-danger" role="alert">${request.responseText || errorThrown}</div>`);
+      $('#command-result').addClass(`label-${statusToClass('FAIL')}`).text(validationStatus('Error'));
+      $('#spinner').hide();
+    }
+
+    showError(message) {
+      $('#error-message').remove();
+      $('#command-details').append(`<div id="error-message" class="alert alert-danger" role="alert">${message}</div>`);
+    }
+
+    isResultStillAwaited() {
+      return $('#command-id').text() == this.commandId && !this.checkCommandStatus('done');
+    }
+
+    setCommandStatus(status) {
+      $('#command-id').data('status', status);
+    }
+
+    checkCommandStatus(status) {
+      return $('#command-id').data('status') == status
+    }
+}
+
+function initReport(url, reportGenerator) {
+    var testResultModalEl = $('#testResultModal');
+    testResultModalEl.on('show.bs.modal', function (event) {
+      let reportGateway = new ReportGateway(url, reportGenerator);
+      reportGateway.order();
+    });
+}


### PR DESCRIPTION
What has been done:
- shifting common js logic from html templates to js file
- shifting spinner style definition to css file
- using template markup for storing a single test case html template
- linking above css/js files to proper admin views