### PR TITLE
Enable task_reject_on_worker_lost for proper reconection when redis server was gone

### DIFF
--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -197,6 +197,8 @@ CELERY_BEAT_MAX_LOOP_INTERVAL = env.int('CELERY_BEAT_MAX_LOOP_INTERVAL', default
 # 5min we will wait for kill task
 CELERY_TASK_SOFT_TIME_LIMIT_SECONDS = env.int('CELERY_TASK_SOFT_TIME_LIMIT_SECONDS', default=300)
 
+CELERY_TASK_REJECT_ON_WORKER_LOST= env.bool('CELERY_TASK_REJECT_ON_WORKER_LOST', default=False)
+
 CELERY_ROUTES = {
     'vaas.router.report.fetch_urls_async': {'queue': 'routes_test_queue'},
     'vaas.cluster.cluster.connect_command': {'queue': 'routes_test_queue'},

--- a/vaas/vaas/settings/celery.py
+++ b/vaas/vaas/settings/celery.py
@@ -27,6 +27,11 @@ app.conf.beat_schedule = {
     },
 }
 
+# After redis conenction troubles 'Connection closed by server / Connection by peer' we allow to re-queued
+# task which was executed when failure occurred. "We know what we are doing."
+# https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-reject-on-worker-lost
+app.conf.task_reject_on_worker_lost = True
+
 # For better handle redis ConenctionError exception we give possibility to configure keepalive and connect_timeout parameters
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#redis-socket-keepalive
 app.conf.redis_socket_keepalive = settings.REDIS_SOCKET_KEEPALIVE

--- a/vaas/vaas/settings/celery.py
+++ b/vaas/vaas/settings/celery.py
@@ -30,7 +30,7 @@ app.conf.beat_schedule = {
 # After redis conenction troubles 'Connection closed by server / Connection by peer' we allow to re-queued
 # task which was executed when failure occurred. "We know what we are doing."
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-reject-on-worker-lost
-app.conf.task_reject_on_worker_lost = True
+app.conf.task_reject_on_worker_lost = settings.CELERY_TASK_REJECT_ON_WORKER_LOST
 
 # For better handle redis ConenctionError exception we give possibility to configure keepalive and connect_timeout parameters
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#redis-socket-keepalive


### PR DESCRIPTION
When redis goes up and down celery worker reconnect the connection but it doesn't execute any tasks.
So even option late acks don't reschedule executed taska and event if there wasn't any task on queue celery cannot start consume new one's that arrived.
Only when: **task_reject_on_worker_lost** are enable, celery automatically re-connection and tasks execution are happened.

How to reconstruct this situation with disabled task_reject_on_worker_lost: 
* simply kill docker with redis and try to reload vcl
* launch again redis
* login in to redis: redis-cli -> LLEN worker_queue 
* Task on queue will be 1
* VaaS send task and celery don't execute it

When task_reject_on_worker_lost are enable this case doesn't occur.