### PR TITLE
Add victoriametrics support + possibility to define global labels for Prometheus metrics

### DIFF
--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -245,7 +245,15 @@ STATSD_PREFIX = env.str('STATSD_PREFIX', default='example.statsd.path')
 PROMETHEUS_ENABLE = env.bool('PROMETHEUS_ENABLE', default=False)
 PROMETHEUS_GATEWAY_HOST = env.str('PROMETHEUS_GATEWAY_HOST', default='localhost')
 PROMETHEUS_GATEWAY_PORT = env.int('PROMETHEUS_GATEWAY_PORT', default=9091)
-PROMETHEUS_GATEWAY_JOB = env.str('PROMETHEUS_GATEWAY_JOB', default='')
+PROMETHEUS_GATEWAY_JOB = env.str('PROMETHEUS_GATEWAY_JOB', default='vaas')
+# Please in env definition stick to the proscription: name=value,second=value
+# It will transfer to: {name: value, second: value}.
+PROMETHEUS_GATEWAY_LABELS = env.dict('PROMETHEUS_GATEWAY_LABELS', default={})
+
+# We also allow push metric via victoriametrics agent.
+# https://docs.victoriametrics.com/#how-to-import-data-in-prometheus-exposition-format
+VICTORIAMETRICS_SUPPORT = env.bool('VICTORIAMETRICS_SUPPORT', default=False)
+VICTORIAMETRICS_PATH = env.str('VICTORIAMETRICS_PATH', default="/api/v1/import/prometheus")
 
 # HEADER FOR PERMIT ACCESS TO /vaas/ ENDPOINT
 ALLOW_METRICS_HEADER = env.bool('ALLOW_METRICS_HEADER', default='x-allow-metric-header')


### PR DESCRIPTION
Example configuration of Prometheus metrics supported by VictoraMetrics:
```bash
PROMETHEUS_ENABLE: True
PROMETHEUS_GATEWAY_PORT: 9091
PROMETHEUS_GATEWAY_JOB: vaas
PROMETHEUS_GATEWAY_LABELS: dc=dc,test=test,somelabels=labes
VICTORIAMETRICS_SUPPORT: True
````
Snippet of pushed metrics:
```bash
PUT /api/v1/import/prometheus/metrics/job/vaas HTTP/1.1
Accept-Encoding: identity
Content-Length: 589
Host: localhost:9091
User-Agent: Python-urllib/3.9
Content-Type: text/plain; version=0.0.4; charset=utf-8
Connection: close

# HELP queue_time_from_order_to_execute_task queue_time_from_order_to_execute_task
# TYPE queue_time_from_order_to_execute_task summary
queue_time_from_order_to_execute_task_count{dc="dc",somelabels="labes",test="test"} 1.0
queue_time_from_order_to_execute_task_sum{dc="dc",somelabels="labes",test="test"} 1.868500839918852e-05
# HELP queue_time_from_order_to_execute_task_created queue_time_from_order_to_execute_task
# TYPE queue_time_from_order_to_execute_task_created gauge
queue_time_from_order_to_execute_task_created{dc="dc",somelabels="labes",test="test"} 1.694068332621746e+09
```