### PR TITLE
make possible to rewrite destination urls by domain mappings

### DIFF
--- a/vaas/vaas/metrics/prometheus.py
+++ b/vaas/vaas/metrics/prometheus.py
@@ -35,7 +35,7 @@ class PrometheusClient:
         """
         Splits dotted name for example "my_metric.label1.value1.label2.value2" into tuple containing:
         - short_name -> "my_metric"
-        - labels ->  {"label1": "value1", "label2": "value2"
+        - labels ->  {"label1": "value1", "label2": "value2"}
         """
         labels = self.labels.copy()
         parts = name.split(".")

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0-canary.vcl
@@ -339,7 +339,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "ce716", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "70175", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -411,6 +411,26 @@ sub vcl_recv {
     unset req.http.x-canary-random;
 
 # Flexible REDIRECT
+    if (req.http.host == "example.prod.org") {
+    if (req.url ~ "/source") {
+        set req.http.x-redirect = "2";
+        set req.http.x-destination = "http://example.prod.org/new_destination";
+        set req.http.x-response-code = "301";
+        set req.http.x-action = "redirect";
+    }
+    else if (req.url ~ "/source") {
+        set req.http.x-redirect = "1";
+        set req.http.x-destination = "http://example.prod.org/destination";
+        set req.http.x-response-code = "301";
+        set req.http.x-action = "redirect";
+    }
+    else if (req.url ~ "/external") {
+        set req.http.x-redirect = "3";
+        set req.http.x-destination = "http://example-external.com/external_destination";
+        set req.http.x-response-code = "301";
+        set req.http.x-action = "redirect";
+    }
+    }
     if (req.http.host == "example.prod.com") {
     if (req.url ~ "/source") {
         set req.http.x-redirect = "2";
@@ -424,17 +444,9 @@ sub vcl_recv {
         set req.http.x-response-code = "301";
         set req.http.x-action = "redirect";
     }
-    }
-    if (req.http.host == "example.prod.org") {
-    if (req.url ~ "/source") {
-        set req.http.x-redirect = "2";
-        set req.http.x-destination = "http://example.prod.org/new_destination";
-        set req.http.x-response-code = "301";
-        set req.http.x-action = "redirect";
-    }
-    else if (req.url ~ "/source") {
-        set req.http.x-redirect = "1";
-        set req.http.x-destination = "http://example.prod.org/destination";
+    else if (req.url ~ "/external") {
+        set req.http.x-redirect = "3";
+        set req.http.x-destination = "http://example-external.com/external_destination";
         set req.http.x-response-code = "301";
         set req.http.x-action = "redirect";
     }

--- a/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
+++ b/vaas/vaas/vcl/tests/expected-vcl-4.0.vcl
@@ -366,7 +366,7 @@ sub vcl_synth {
     if (resp.status == 989) {
         set resp.status = 200;
         set resp.http.Content-Type = "application/json";
-        synthetic ( {"{ "vcl_version" : "721d3", "varnish_status": "disabled" }"} );
+        synthetic ( {"{ "vcl_version" : "34535", "varnish_status": "disabled" }"} );
         return (deliver);
     }
 }
@@ -438,6 +438,26 @@ sub vcl_recv {
     unset req.http.x-canary-random;
 
 # Flexible REDIRECT
+    if (req.http.host == "example.prod.org") {
+    if (req.url ~ "/source") {
+        set req.http.x-redirect = "2";
+        set req.http.x-destination = "http://example.prod.org/new_destination";
+        set req.http.x-response-code = "301";
+        set req.http.x-action = "redirect";
+    }
+    else if (req.url ~ "/source") {
+        set req.http.x-redirect = "1";
+        set req.http.x-destination = "http://example.prod.org/destination";
+        set req.http.x-response-code = "301";
+        set req.http.x-action = "redirect";
+    }
+    else if (req.url ~ "/external") {
+        set req.http.x-redirect = "3";
+        set req.http.x-destination = "http://example-external.com/external_destination";
+        set req.http.x-response-code = "301";
+        set req.http.x-action = "redirect";
+    }
+    }
     if (req.http.host == "example.prod.com") {
     if (req.url ~ "/source") {
         set req.http.x-redirect = "2";
@@ -451,17 +471,9 @@ sub vcl_recv {
         set req.http.x-response-code = "301";
         set req.http.x-action = "redirect";
     }
-    }
-    if (req.http.host == "example.prod.org") {
-    if (req.url ~ "/source") {
-        set req.http.x-redirect = "2";
-        set req.http.x-destination = "http://example.prod.org/new_destination";
-        set req.http.x-response-code = "301";
-        set req.http.x-action = "redirect";
-    }
-    else if (req.url ~ "/source") {
-        set req.http.x-redirect = "1";
-        set req.http.x-destination = "http://example.prod.org/destination";
+    else if (req.url ~ "/external") {
+        set req.http.x-redirect = "3";
+        set req.http.x-destination = "http://example-external.com/external_destination";
         set req.http.x-response-code = "301";
         set req.http.x-action = "redirect";
     }


### PR DESCRIPTION
Rationale:
The current approach assumes that if the mapping exists for the destination URL domain then such domain should be replaced by **source** domain mapping. Such an assumption has no justification. The new approach is based on simple logic:
- if source and destination domains share the same mappings then the destination URL is replaced by matched source domain
- in another case if there exists **exactly one** mapping for the destination domain such mapping is used
- if any of the above conditions are met by the default destination domain it is used without any altering

What has been done
- changing __init__ for VclRedirect object (we additionally pass there destination URL)
- adding helper methods that provide all mapping for the parsed destination domain
- implementing logic according to the rules described above