### PR TITLE
Migrate nginx images to be build from Dockerfile same as the varnishes

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   celery-worker:
     entrypoint: [ '/entrypoint-celery-worker.sh' ]
@@ -49,42 +47,48 @@ services:
 
   # Varnishes & nginx
   nginx-0:
-    image: allegro/vaas-nginx
+    build: ./docker/nginx
+    image: vaas-nginx
     expose:
       - "80"
     networks:
       vaas:
         ipv4_address: 192.168.199.10
   nginx-1:
-    image: allegro/vaas-nginx
+    build: ./docker/nginx
+    image: vaas-nginx
     expose:
       - "80"
     networks:
       vaas:
         ipv4_address: 192.168.199.11
   nginx-2:
-    image: allegro/vaas-nginx
+    build: ./docker/nginx
+    image: vaas-nginx
     expose:
       - "80"
     networks:
       vaas:
         ipv4_address: 192.168.199.12
   nginx-3:
-    image: allegro/vaas-nginx
+    build: ./docker/nginx
+    image: vaas-nginx
     expose:
       - "80"
     networks:
       vaas:
         ipv4_address: 192.168.199.13
   nginx-4:
-    image: allegro/vaas-nginx
+    build: ./docker/nginx
+    image: vaas-nginx
     expose:
       - "80"
     networks:
       vaas:
         ipv4_address: 192.168.199.14
   nginx-5:
-    image: allegro/vaas-nginx
+    build: ./docker/nginx
+    image: vaas-nginx
     expose:
       - "80"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   mysql:
     image: mysql:5.7


### PR DESCRIPTION
The nginx images were pulled from the docker.io which was built 8 years ago, so the format of the image (nginx) now stops being supported by the Docker 
```bash
(master) $ docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build
WARN[0000] /Users/artur.mackowiak/Projects/Pluton/vaas_software/vaas/docker-compose.yml: `version` is obsolete
WARN[0000] /Users/artur.mackowiak/Projects/Pluton/vaas_software/vaas/docker-compose.override.yml: `version` is obsolete
[+] Running 2/6
 ✘ nginx-5 Error   context 5.5s
 ⠼ nginx-1 Pulling 5.5s
 ⠼ nginx-4 Pulling 5.5s
 ⠼ nginx-3 Pulling 5.5s
 ✘ nginx-2 Error   context canceled 5.5s
 ⠼ nginx-0 Pulling 5.5s
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/allegro/vaas-nginx:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
(master) $ 
```
What has been done:
- add the build fields in docker compose definitions for nginx that it starts to be built locally based on Docker file
- get rid of version key in compose definitions because of obsoletion