### PR TITLE
Fix VCL template name being "object" instead of actual name after block creation

### DIFF
--- a/vaas/vaas/cluster/models.py
+++ b/vaas/vaas/cluster/models.py
@@ -245,6 +245,9 @@ class VclTemplateBlock(models.Model):
     def clean(self):
         vcl_variable_validator(self.content, self.template.pk, VclVariable, VarnishServer)
 
+    def __str__(self):
+        return f"{self.template.name} - {self.tag}"
+
     class Meta:
         unique_together = (('tag', 'template'))
 


### PR DESCRIPTION
<img width="1314" height="605" alt="image" src="https://github.com/user-attachments/assets/3493874f-0b77-4702-b39f-1c7a9c1c9792" />
