### PR TITLE
Moved uuid into bottom part of tabs and fixed history button

### DIFF
--- a/vaas/vaas/adminext/templates/admin/router/redirect/change_form.html
+++ b/vaas/vaas/adminext/templates/admin/router/redirect/change_form.html
@@ -1,15 +1,18 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls static admin_modify %}
+{% load i18n admin_urls static admin_modify jazzmin %}
 
-{% block submit_buttons_bottom %}
-{% submit_row %}
-{% if original %}
-<style>
-    .label-lightgray {
-      background-color: lightgray;
-    }
-  </style>
-
-<span class="label label-lightgray pull-right">uuid: {{original.uuid}}</span>
-{% endif %}
+{% block field_sets %}
+<div class="col-12 col-lg-9">
+  <div class="card">
+    <div class="card-body">
+      {% get_changeform_template adminform as changeform_template %}
+      {% include changeform_template %}
+    </div>
+    <div class="card-footer">
+      {% if original %}
+        <span class="badge badge-secondary">uuid: {{original.uuid}}</span>
+      {% endif %}
+    </div>
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
What has been done:
1. Fixed bootstrap component (`label` -> `badge`) and aligned to ootb styling
2. Moved uuid field from `submit button block` into footer of `field set block` - it position near buttons was not clear in already busy area
3. History button is again available - it was not present as we were overriding too many parts of the block and also not used `{{block.super}}`. As per point 2 - this is no longer relevant

Screenshot
<img width="912" height="632" alt="image" src="https://github.com/user-attachments/assets/30bfcf2c-b310-496d-8030-90b2344f4002" />
