### PR TITLE
Fix fa-ban icon in backend listing

### DIFF
--- a/vaas/vaas/manager/admin.py
+++ b/vaas/vaas/manager/admin.py
@@ -249,7 +249,7 @@ class BackendAdmin(AuditableModelAdmin):
             else:
                 return format_html(
                     "<div class='span13 text-center'><a class='btn btn-xs btn-danger' href='#'>"
-                    "<i class=;fa-solid fa-ban'></i></a></div>"
+                    "<i class='fa-solid fa-ban'></i></a></div>"
                 )
         else:
             return format_html(


### PR DESCRIPTION
Fixing the typo
<img width="1916" height="970" alt="Screenshot 2025-09-15 at 13 43 59" src="https://github.com/user-attachments/assets/f921198a-122e-478a-85e5-c42d64571584" />
