### PR TITLE
Change in the search_felds get_mapping to the mapping_list

### DIFF
--- a/vaas/vaas/cluster/admin.py
+++ b/vaas/vaas/cluster/admin.py
@@ -204,7 +204,7 @@ class VclTemplateBlockAdmin(HistoryMixinAdmin, SimpleHistoryAdmin):
 
 class DomainMappingAdmin(HistoryMixinAdmin, SimpleHistoryAdmin):
     form = DomainMappingForm
-    search_fields = ["domain", "get_mappings", "type", "clusters__name"]
+    search_fields = ["domain", "mappings_list", "type", "clusters__name"]
     list_display = ["domain", "get_mappings", "type", "get_clusters"]
 
     def get_mappings(self, obj: DomainMapping) -> str:


### PR DESCRIPTION
This pull request makes a minor update to the `DomainMappingAdmin` configuration in the Django admin. The change updates the `search_fields` list to use the correct field name for searching mappings.

- Admin configuration: Updated the `search_fields` in `DomainMappingAdmin` to use `mappings_list` instead of the incorrect `get_mappings`, ensuring admin search works as intended.

<img width="1917" height="937" alt="Screenshot 2026-01-09 at 12 13 44" src="https://github.com/user-attachments/assets/947f5627-e89d-4a59-b0aa-9c2bdb0751ea" />
