### PR TITLE
Extend the vaas by the CELERY_WORKER_HIJACK_ROOT_LOGGER flat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,22 @@ VOLUME ["/home/app/plugins"]
 
 RUN apt update \
   && apt install -y --no-install-recommends \
-    curl \
-    git \
-    default-libmysqlclient-dev \
-    build-essential \
-    default-mysql-client \
-    pkg-config \
-    libxml2  \
-    libxml2-dev \
-    libxslt1.1 \
-    libxslt1.1-dev \
-    python3.12 \
-    python3.12-dev \
-    python3.12-venv \
-    python3-pip \
-    python3-setuptools \
+  curl \
+  git \
+  gcc \
+  libpcre3-dev \
+  default-libmysqlclient-dev \
+  build-essential \
+  default-mysql-client \
+  pkg-config \
+  libxml2  \
+  libxml2-dev \
+  libxslt1.1 \
+  python3.12 \
+  python3.12-dev \
+  python3.12-venv \
+  python3-pip \
+  python3-setuptools \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/vaas/vaas/settings/base.py
+++ b/vaas/vaas/settings/base.py
@@ -218,6 +218,9 @@ REFRESH_TRIGGERS_CLASS = tuple(
     )
 )
 
+CELERY_WORKER_HIJACK_ROOT_LOGGER = env.bool(
+    "CELERY_WORKER_HIJACK_ROOT_LOGGER", default=False
+)
 CELERY_TASK_RESULT_EXPIRES = env.int("CELERY_TASK_RESULT_EXPIRES", default=600)
 CELERY_TASK_SERIALIZER = env.str("CELERY_TASK_SERIALIZER", default="json")
 CELERY_RESULT_SERIALIZER = env.str("CELERY_RESULT_SERIALIZER", default="json")
@@ -459,7 +462,7 @@ JAZZMIN_SETTINGS = {
         "manager.probe": "fas fa-heartbeat",
         "manager.timeprofile": "fas fa-clock",
         "router.redirect": "fas fa-directions",
-        "router.route": "fas fa-route"
+        "router.route": "fas fa-route",
     },
     # Icons that are used when one is not manually specified
     "default_icon_parents": "fas fa-chevron-circle-right",
@@ -596,3 +599,4 @@ CHANGEFORM_TEMPLATES = {
 }
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
+

--- a/vaas/vaas/settings/celery.py
+++ b/vaas/vaas/settings/celery.py
@@ -24,6 +24,12 @@ def debug_task(self):
 # Override the celery.log as defined in settings LOGGING
 app.conf.worker_hijack_root_logger = settings.CELERY_WORKER_HIJACK_ROOT_LOGGER
 
+
+@setup_logging.connect
+def configure_celery_logging(*args, **kwargs):
+    logging.config.dictConfig(settings.LOGGING)
+
+
 app.conf.beatx_store = settings.BROKER_URL
 app.conf.beat_max_loop_interval = settings.CELERY_BEAT_MAX_LOOP_INTERVAL
 app.conf.beat_schedule = {

--- a/vaas/vaas/settings/celery.py
+++ b/vaas/vaas/settings/celery.py
@@ -21,7 +21,7 @@ def debug_task(self):
     print("Request: {0!r}".format(self.request))
 
 
-# For overrode the celery.log by the defined in setettings
+# Override the celery.log as defined in settings LOGGING
 app.conf.worker_hijack_root_logger = settings.CELERY_WORKER_HIJACK_ROOT_LOGGER
 
 app.conf.beatx_store = settings.BROKER_URL

--- a/vaas/vaas/settings/celery.py
+++ b/vaas/vaas/settings/celery.py
@@ -2,13 +2,15 @@
 from __future__ import absolute_import
 
 from celery import Celery
+from celery.signals import setup_logging
 from django.conf import settings
+import logging.config
 
-app = Celery('vaas')
+app = Celery("vaas")
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
+app.config_from_object("django.conf:settings")
 app.conf.update(result_extended=True)
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
@@ -16,14 +18,18 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 @app.task(bind=True)
 def debug_task(self):
-    print('Request: {0!r}'.format(self.request))
+    print("Request: {0!r}".format(self.request))
+
+
+# For overrode the celery.log by the defined in setettings
+app.conf.worker_hijack_root_logger = settings.CELERY_WORKER_HIJACK_ROOT_LOGGER
 
 app.conf.beatx_store = settings.BROKER_URL
 app.conf.beat_max_loop_interval = settings.CELERY_BEAT_MAX_LOOP_INTERVAL
 app.conf.beat_schedule = {
-    'refresh_backend_statuses': {
-        'task': 'vaas.monitor.tasks.refresh_backend_statuses',
-        'schedule': settings.BACKEND_STATUSES_UPDATE_INTERVAL_SECONDS,
+    "refresh_backend_statuses": {
+        "task": "vaas.monitor.tasks.refresh_backend_statuses",
+        "schedule": settings.BACKEND_STATUSES_UPDATE_INTERVAL_SECONDS,
     },
 }
 
@@ -42,4 +48,6 @@ app.conf.redis_socket_connect_timeout = settings.REDIS_SOCKET_CONNECT_TIMEOUT
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#redis-socket-timeout
 app.conf.redis_socket_timeout = settings.REDIS_SOCKET_TIMEOUT
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html?highlight=redis_retry_on_timeout#redis-backend-health-check-interval
-app.conf.redis_backend_health_check_interval = settings.REDIS_BACKEND_HEALTH_CHECK_INTERVAL_SEC
+app.conf.redis_backend_health_check_interval = (
+    settings.REDIS_BACKEND_HEALTH_CHECK_INTERVAL_SEC
+)


### PR DESCRIPTION
**Celery configuration and logging improvements:**
* Added a new setting `CELERY_WORKER_HIJACK_ROOT_LOGGER` in `vaas/vaas/settings/base.py` to allow configuration of whether Celery workers should hijack the root logger.
* Updated `vaas/vaas/settings/celery.py` to set `worker_hijack_root_logger` in the Celery app configuration based on the new setting, enabling more flexible logging control.

**Dependency and code consistency updates:**

* Added `gcc` and `libpcre3-dev` to the `Dockerfile` install list to ensure all necessary build dependencies are present.
* Minor code style and formatting improvements in Celery and settings files for consistency (e.g., quote usage, trailing commas, line breaks).