### PR TITLE
Set the latest working version for jazzmin - modals were not working after latest version rollout (3.0.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt update \
     libxml2  \
     libxml2-dev \
     libxslt1.1 \
-    libxslt1.1-dev \
+    libxslt1-dev \
     python3.12 \
     python3.12-dev \
     python3.12-venv \

--- a/vaas/requirements/base.txt
+++ b/vaas/requirements/base.txt
@@ -22,7 +22,7 @@ lxml==6.0.0
 flower==2.0.1
 
 # Django Admin Theme
-django-jazzmin
+django-jazzmin==3.0.1
 
 # JSON logging
 python-json-logger


### PR DESCRIPTION
Changed libxslt1.1-dev to libxslt1-dev as the .1 not existed